### PR TITLE
remove -msse4.1 flag on non x86 architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,14 @@ endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Compile options
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+    set(SSE_FLAG -msse4.1)
+endif()
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(COMPILE_OPTIONS -msse4.1 -Wextra -Wno-missing-field-initializers)
+    set(COMPILE_OPTIONS ${SSE_FLAG} -Wextra -Wno-missing-field-initializers)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    set(COMPILE_OPTIONS -msse4.1 -Wextra -Wno-missing-field-initializers)
+    set(COMPILE_OPTIONS ${SSE_FLAG} -Wextra -Wno-missing-field-initializers)
 elseif(MSVC)
     set(COMPILE_OPTIONS
         /W4 /WX


### PR DESCRIPTION
fix for failing build on aarch64