### PR TITLE
Fix vulkan linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,8 @@ if(NRI_ENABLE_D3D12_SUPPORT)
 endif()
 
 if(NRI_ENABLE_VK_SUPPORT)
+    find_package(Vulkan REQUIRED)
+
     # Vulkan headers
     FetchContent_Declare(
         vulkan_headers
@@ -446,6 +448,11 @@ if(NRI_ENABLE_VK_SUPPORT)
     target_compile_definitions(NRI_VK PRIVATE ${COMPILE_DEFINITIONS})
     target_compile_options(NRI_VK PRIVATE ${COMPILE_OPTIONS})
     target_link_libraries(NRI_VK PRIVATE NRI_Shared)
+    target_link_libraries(NRI_VK PRIVATE
+            NRI_Shared
+            ${Vulkan_LIBRARIES}
+    )
+    target_include_directories(NRI_VK PRIVATE ${Vulkan_INCLUDE_DIRS})
     set_property(TARGET NRI_VK PROPERTY FOLDER ${PROJECT_NAME})
 
     if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,8 +231,6 @@ if(NRI_ENABLE_D3D12_SUPPORT)
 endif()
 
 if(NRI_ENABLE_VK_SUPPORT)
-    find_package(Vulkan REQUIRED)
-
     # Vulkan headers
     FetchContent_Declare(
         vulkan_headers
@@ -448,11 +446,14 @@ if(NRI_ENABLE_VK_SUPPORT)
     target_compile_definitions(NRI_VK PRIVATE ${COMPILE_DEFINITIONS})
     target_compile_options(NRI_VK PRIVATE ${COMPILE_OPTIONS})
     target_link_libraries(NRI_VK PRIVATE NRI_Shared)
-    target_link_libraries(NRI_VK PRIVATE
-            NRI_Shared
-            ${Vulkan_LIBRARIES}
-    )
-    target_include_directories(NRI_VK PRIVATE ${Vulkan_INCLUDE_DIRS})
+    if(APPLE)
+        find_package(Vulkan REQUIRED)
+        target_link_libraries(NRI_VK PRIVATE
+                NRI_Shared
+                ${Vulkan_LIBRARIES}
+        )
+        target_include_directories(NRI_VK PRIVATE ${Vulkan_INCLUDE_DIRS})
+    endif()
     set_property(TARGET NRI_VK PROPERTY FOLDER ${PROJECT_NAME})
 
     if(WIN32)


### PR DESCRIPTION
When running samples using CLion's cmake run targets instead of the terminal, executables fail to launch. The problem is `Failed to load Vulkan loader`. Seems like when running from an environment where vulkan environment variables are not set vulkan loader cannot be found. Finding and linking Vulkan in CMakeLists fixes the problem.

I think I linked at the correct place but needs checking.
