### PR TITLE
fix: Add null check before destroying `m_ConstantBuffer`

### DIFF
--- a/Source/Shared/StreamerInterface.hpp
+++ b/Source/Shared/StreamerInterface.hpp
@@ -7,7 +7,9 @@ StreamerImpl::~StreamerImpl() {
     for (GarbageInFlight& garbageInFlight : m_GarbageInFlight)
         m_iCore.DestroyBuffer(*garbageInFlight.buffer);
 
-    m_iCore.DestroyBuffer(*m_ConstantBuffer);
+    if (m_ConstantBuffer) {
+        m_iCore.DestroyBuffer(*m_ConstantBuffer);
+    }
     m_iCore.DestroyBuffer(*m_DynamicBuffer);
 }
 


### PR DESCRIPTION
In Release builds, when the optional `m_ConstantBuffer` is not created, the destructor would dereference a null pointer, causing a crash.