### PR TITLE
Validate memory is bound before creating views

### DIFF
--- a/Source/Validation/DeviceVal.hpp
+++ b/Source/Validation/DeviceVal.hpp
@@ -226,7 +226,11 @@ NRI_INLINE Result DeviceVal::CreateDescriptor(const BufferViewDesc& bufferViewDe
     RETURN_ON_FAILURE(this, bufferViewDesc.format < Format::MAX_NUM, Result::INVALID_ARGUMENT, "'format' is invalid");
     RETURN_ON_FAILURE(this, bufferViewDesc.viewType < BufferViewType::MAX_NUM, Result::INVALID_ARGUMENT, "'viewType' is invalid");
 
-    const BufferDesc& bufferDesc = ((BufferVal*)bufferViewDesc.buffer)->GetDesc();
+    const BufferVal& bufferVal = *(BufferVal*)bufferViewDesc.buffer;
+    const BufferDesc& bufferDesc = bufferVal.GetDesc();
+
+    RETURN_ON_FAILURE(this, bufferVal.IsBoundToMemory(), Result::INVALID_ARGUMENT, "'bufferViewDesc.buffer' is not bound to memory");
+
     RETURN_ON_FAILURE(this, bufferViewDesc.offset + bufferViewDesc.size <= bufferDesc.size, Result::INVALID_ARGUMENT, "'offset=%" PRIu64 "' + 'size=%" PRIu64 "' must be <= buffer 'size=%" PRIu64 "'", bufferViewDesc.offset, bufferViewDesc.size, bufferDesc.size);
 
     auto bufferViewDescImpl = bufferViewDesc;
@@ -247,7 +251,10 @@ NRI_INLINE Result DeviceVal::CreateDescriptor(const Texture1DViewDesc& textureVi
     RETURN_ON_FAILURE(this, textureViewDesc.viewType < Texture1DViewType::MAX_NUM, Result::INVALID_ARGUMENT, "'viewType' is invalid");
     RETURN_ON_FAILURE(this, textureViewDesc.format > Format::UNKNOWN && textureViewDesc.format < Format::MAX_NUM, Result::INVALID_ARGUMENT, "'format' is invalid");
 
-    const TextureDesc& textureDesc = ((TextureVal*)textureViewDesc.texture)->GetDesc();
+    const TextureVal& textureVal = *(TextureVal*)textureViewDesc.texture;
+    const TextureDesc& textureDesc = textureVal.GetDesc();
+
+    RETURN_ON_FAILURE(this, textureVal.IsBoundToMemory(), Result::INVALID_ARGUMENT, "'textureViewDesc.texture' is not bound to memory");
 
     RETURN_ON_FAILURE(this, textureViewDesc.mipOffset + textureViewDesc.mipNum <= textureDesc.mipNum, Result::INVALID_ARGUMENT,
         "'mipOffset=%u' + 'mipNum=%u' must be <= texture 'mipNum=%u'", textureViewDesc.mipOffset, textureViewDesc.mipNum, textureDesc.mipNum);
@@ -273,7 +280,10 @@ NRI_INLINE Result DeviceVal::CreateDescriptor(const Texture2DViewDesc& textureVi
     RETURN_ON_FAILURE(this, textureViewDesc.viewType < Texture2DViewType::MAX_NUM, Result::INVALID_ARGUMENT, "'viewType' is invalid");
     RETURN_ON_FAILURE(this, textureViewDesc.format > Format::UNKNOWN && textureViewDesc.format < Format::MAX_NUM, Result::INVALID_ARGUMENT, "'format' is invalid");
 
-    const TextureDesc& textureDesc = ((TextureVal*)textureViewDesc.texture)->GetDesc();
+    const TextureVal& textureVal = *(TextureVal*)textureViewDesc.texture;
+    const TextureDesc& textureDesc = textureVal.GetDesc();
+
+    RETURN_ON_FAILURE(this, textureVal.IsBoundToMemory(), Result::INVALID_ARGUMENT, "'textureViewDesc.texture' is not bound to memory");
 
     RETURN_ON_FAILURE(this, textureViewDesc.mipOffset + textureViewDesc.mipNum <= textureDesc.mipNum, Result::INVALID_ARGUMENT,
         "'mipOffset=%u' + 'mipNum=%u' must be <= texture 'mipNum=%u'", textureViewDesc.mipOffset, textureViewDesc.mipNum, textureDesc.mipNum);
@@ -299,7 +309,10 @@ NRI_INLINE Result DeviceVal::CreateDescriptor(const Texture3DViewDesc& textureVi
     RETURN_ON_FAILURE(this, textureViewDesc.viewType < Texture3DViewType::MAX_NUM, Result::INVALID_ARGUMENT, "'viewType' is invalid");
     RETURN_ON_FAILURE(this, textureViewDesc.format > Format::UNKNOWN && textureViewDesc.format < Format::MAX_NUM, Result::INVALID_ARGUMENT, "'format' is invalid");
 
-    const TextureDesc& textureDesc = ((TextureVal*)textureViewDesc.texture)->GetDesc();
+    const TextureVal& textureVal = *(TextureVal*)textureViewDesc.texture;
+    const TextureDesc& textureDesc = textureVal.GetDesc();
+
+    RETURN_ON_FAILURE(this, textureVal.IsBoundToMemory(), Result::INVALID_ARGUMENT, "'textureViewDesc.texture' is not bound to memory");
 
     RETURN_ON_FAILURE(this, textureViewDesc.mipOffset + textureViewDesc.mipNum <= textureDesc.mipNum, Result::INVALID_ARGUMENT,
         "'mipOffset=%u' + 'mipNum=%u' must be <= texture 'mipNum=%u'", textureViewDesc.mipOffset, textureViewDesc.mipNum, textureDesc.mipNum);


### PR DESCRIPTION
I accidentally moved the resource allocation below creating the texture view.

```c++
nri::Texture2DViewDesc texture2DViewDesc{
    .texture = _graphicsTexture->texture,
    .viewType = nri::Texture2DViewType::SHADER_RESOURCE_2D,
    .format = _format,
};
NRI_ABORT_ON_FAILURE(nri.CreateTexture2DView(texture2DViewDesc, _graphicsTexture->view));

...

nri::ResourceGroupDesc resourceGroupDesc = {};
resourceGroupDesc.memoryLocation = nri::MemoryLocation::DEVICE;
resourceGroupDesc.textureNum = 1;
nri::Texture* gpuTexture = _triangleSample.m_Texture;
resourceGroupDesc.textures = &gpuTexture;

_triangleSample.m_MemoryAllocations.resize(NRI.CalculateAllocationNumber(*m_Device, resourceGroupDesc), nullptr);
NRI_ABORT_ON_FAILURE(NRI.AllocateAndBindMemory(*m_Device, resourceGroupDesc, _triangleSample.m_MemoryAllocations.data() + 1));

```

While this technically does run without errors, it produces a black image

<img width="1920" height="1131" alt="image" src="https://github.com/user-attachments/assets/0a77300f-f405-453f-963d-518e6b45a8a4" />


I propose adding validation to ensure memory is bound before creating a view to prevent this bug