### PR TITLE
Fix D3D11 zero buffer initialization

### DIFF
--- a/Source/D3D11/DeviceD3D11.hpp
+++ b/Source/D3D11/DeviceD3D11.hpp
@@ -305,7 +305,7 @@ Result DeviceD3D11::Create(const DeviceCreationDesc& desc, const DeviceCreationD
         D3D11_SUBRESOURCE_DATA data = {};
         data.pSysMem = zeros;
 
-        hr = m_Device->CreateBuffer(&zeroBufferDesc, nullptr, &m_ZeroBuffer);
+        hr = m_Device->CreateBuffer(&zeroBufferDesc, &data, &m_ZeroBuffer);
         RETURN_ON_BAD_HRESULT(this, hr, "ID3D11Device::CreateBuffer");
 
         allocator.Free(allocator.userArg, zeros);


### PR DESCRIPTION
The CreateBuffer call was passing nullptr instead of the prepared zero data, causing the buffer to contain uninitialized memory instead of the intended zeroes. This could cause ZeroBuffer operations to copy garbage data instead of actually clearing target buffers to zeroes.