### PR TITLE
Root signature is now created through the Agility SDK properly if independent devices are used

### DIFF
--- a/Source/D3D12/PipelineLayoutD3D12.hpp
+++ b/Source/D3D12/PipelineLayoutD3D12.hpp
@@ -245,7 +245,19 @@ Result PipelineLayoutD3D12::Create(const PipelineLayoutDesc& pipelineLayoutDesc)
 
     ComPtr<ID3DBlob> rootSignatureBlob;
     ComPtr<ID3DBlob> errorBlob;
-    HRESULT hr = D3D12SerializeVersionedRootSignature(&rootSignatureDesc, &rootSignatureBlob, &errorBlob);
+    
+    ComPtr<ID3D12DeviceConfiguration1> deviceConfig;
+    m_Device->QueryInterface(IID_PPV_ARGS(&deviceConfig));
+
+    HRESULT hr;
+    
+    if(deviceConfig)
+        hr = deviceConfig->SerializeVersionedRootSignature(
+            &rootSignatureDesc, &rootSignatureBlob, &errorBlob
+        );
+    
+    else hr = D3D12SerializeVersionedRootSignature(&rootSignatureDesc, &rootSignatureBlob, &errorBlob);
+    
     RETURN_ON_BAD_HRESULT(&m_Device, hr, "D3D12SerializeVersionedRootSignature");
 
     if (errorBlob)


### PR DESCRIPTION
This solves potential problems when using [independent devices with d3d12](https://microsoft.github.io/DirectX-Specs/d3d/IndependentDevices.html) that cause D3D12SerializeVersionedRootSignature to fallback to the [default one in the OS](https://discord.com/channels/590611987420020747/590965902564917258/1404927204651171872), meaning that any root signature that uses new functionality introduced by the agility SDK in NRI will fail.
Independent devices can be used for multiple reasons; having two separate devices in a single program or being able to tell the API what agility sdk it should use without poluting the exe's symbols.