### PR TITLE
Fix build with clang++ (non MSVC frontend) on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,13 +383,13 @@ target_compile_options(NRI_Shared
     PUBLIC
         # Options for Clang/GCC compilers
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
-            -Wno-missing-field-initializers
             $<$<NOT:$<CXX_COMPILER_FRONTEND_VARIANT:MSVC>>:
                 -Wextra
                 -Werror
-                -fPIC
+                $<$<NOT:$<BOOL:${WIN32}>>:-fPIC> # add fPIC if not on windows
                 -fvisibility=hidden
             >
+            -Wno-missing-field-initializers # add after werror and wextra
         >
         # Options for MSVC frontend
         $<$<CXX_COMPILER_FRONTEND_VARIANT:MSVC>:


### PR DESCRIPTION
LLVM version 21.1.1

windows build fails when building with UNIX frontend clang++, `-Wno-missing-field-initializers` needs to be after `-Werror` to work, also if `-fPIC` is added we get `error: unsupported option '-fPIC' for target 'x86_64-pc-windows-msvc'`.

`POSITION_INDEPENDENT_CODE` cmake target property can be also used instead of `fPIC` but I kept the original.