### PR TITLE
Clamp swapchain dimensions to fix window scaling on X11

### DIFF
--- a/Source/VK/SwapChainVK.h
+++ b/Source/VK/SwapChainVK.h
@@ -61,6 +61,8 @@ private:
     uint64_t m_PresentId = 0;
     uint32_t m_TextureIndex = 0;
     SwapChainBits m_Flags = SwapChainBits::NONE;
+    uint32_t m_Width = 0;
+    uint32_t m_Height = 0;
 };
 
 } // namespace nri


### PR DESCRIPTION
Previously, when I tried to resize the swapchain on X11 with 125% window scale, the app would crash with this error:
```
ERROR (SwapChainVK.hpp:110) - VK::AMD Radeon Vega 8 Graphics (RADV RAVEN) - Create: swapChainDesc.width is out of [2698, 2698] range
```
Interestingly this only happens if I try resizing by dragging one of the window corners: if I doubleclick on the window decoration to fullscreen it, it works fine.

With this fix, the app will just print tons of warnings instead of crashing, resizing works fine:
```
WARNING (SwapChainVK.hpp:123) - VK::AMD Radeon Vega 8 Graphics (RADV RAVEN) - Create(): swapChainDesc dimensions clamped to [2442, 1362]
WARNING (SwapChainVK.hpp:123) - VK::AMD Radeon Vega 8 Graphics (RADV RAVEN) - Create(): swapChainDesc dimensions clamped to [2412, 1352]
WARNING (SwapChainVK.hpp:123) - VK::AMD Radeon Vega 8 Graphics (RADV RAVEN) - Create(): swapChainDesc dimensions clamped to [2380, 1340]
WARNING (SwapChainVK.hpp:123) - VK::AMD Radeon Vega 8 Graphics (RADV RAVEN) - Create(): swapChainDesc dimensions clamped to [2230, 1294]
WARNING (SwapChainVK.hpp:123) - VK::AMD Radeon Vega 8 Graphics (RADV RAVEN) - Create(): swapChainDesc dimensions clamped to [2188, 1280]
WARNING (SwapChainVK.hpp:123) - VK::AMD Radeon Vega 8 Graphics (RADV RAVEN) - Create(): swapChainDesc dimensions clamped to [2100, 1240]
WARNING (SwapChainVK.hpp:123) - VK::AMD Radeon Vega 8 Graphics (RADV RAVEN) - Create(): swapChainDesc dimensions clamped to [1360, 738]
...
```

This is kind of a dirty fix, but I really have no other idea how to prevent this. Could it be an incorrect configuration of `VkSwapchainPresentScalingCreateInfoEXT`? It could also be an issue of XWayland or the Linux AMD drivers...