### PR TITLE
Allow D3D12 Agility interface fallback

### DIFF
--- a/Source/D3D12/CommandBufferD3D12.hpp
+++ b/Source/D3D12/CommandBufferD3D12.hpp
@@ -27,7 +27,11 @@ static HRESULT QueryLatestInterface(ComPtr<ID3D12GraphicsCommandListBest>& in, C
 
     version = n - i - 1;
 
+#if NRI_ENABLE_AGILITY_SDK_SUPPORT
+    return i < n && version >= 6 ? S_OK : D3D12_ERROR_INVALID_REDIST;
+#else
     return i == 0 ? S_OK : D3D12_ERROR_INVALID_REDIST;
+#endif
 }
 
 #if NRI_ENABLE_AGILITY_SDK_SUPPORT

--- a/Source/D3D12/DescriptorD3D12.hpp
+++ b/Source/D3D12/DescriptorD3D12.hpp
@@ -427,8 +427,30 @@ Result DescriptorD3D12::Create(const SamplerDesc& samplerDesc) {
         desc.FloatBorderColor[3] = samplerDesc.borderColor.f.w;
     }
 
-    HRESULT hr = m_Device->TryCreateSampler2(&desc, {m_DescriptorHandleCPU});
-    NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateSampler2");
+    if (m_Device.GetVersion() >= 15) {
+        HRESULT hr = m_Device->TryCreateSampler2(&desc, {m_DescriptorHandleCPU});
+        NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateSampler2");
+    } else {
+        D3D12_SAMPLER_DESC descLegacy = {};
+        descLegacy.Filter = GetFilter(samplerDesc);
+        descLegacy.AddressU = GetAddressMode(samplerDesc.addressModes.u);
+        descLegacy.AddressV = GetAddressMode(samplerDesc.addressModes.v);
+        descLegacy.AddressW = GetAddressMode(samplerDesc.addressModes.w);
+        descLegacy.MipLODBias = samplerDesc.mipBias;
+        descLegacy.MaxAnisotropy = samplerDesc.anisotropy;
+        descLegacy.ComparisonFunc = GetCompareOp(samplerDesc.compareOp);
+        descLegacy.MinLOD = samplerDesc.mipMin;
+        descLegacy.MaxLOD = samplerDesc.mipMax;
+
+        if (!samplerDesc.isInteger) {
+            descLegacy.BorderColor[0] = samplerDesc.borderColor.f.x;
+            descLegacy.BorderColor[1] = samplerDesc.borderColor.f.y;
+            descLegacy.BorderColor[2] = samplerDesc.borderColor.f.z;
+            descLegacy.BorderColor[3] = samplerDesc.borderColor.f.w;
+        }
+
+        m_Device->CreateSampler(&descLegacy, {m_DescriptorHandleCPU});
+    }
 #else
     D3D12_SAMPLER_DESC desc = {};
     desc.Filter = GetFilter(samplerDesc);
@@ -464,8 +486,11 @@ Result DescriptorD3D12::CreateConstantBufferView(const D3D12_CONSTANT_BUFFER_VIE
     m_DescriptorHandleCPU = m_Device.GetDescriptorHandleCPU(m_Handle);
 
 #if NRI_ENABLE_AGILITY_SDK_SUPPORT
-    HRESULT hr = m_Device->TryCreateConstantBufferView(&desc, {m_DescriptorHandleCPU});
-    NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateConstantBufferView");
+    if (m_Device.GetVersion() >= 15) {
+        HRESULT hr = m_Device->TryCreateConstantBufferView(&desc, {m_DescriptorHandleCPU});
+        NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateConstantBufferView");
+    } else
+        m_Device->CreateConstantBufferView(&desc, {m_DescriptorHandleCPU});
 #else
     m_Device->CreateConstantBufferView(&desc, {m_DescriptorHandleCPU});
 #endif
@@ -483,8 +508,11 @@ Result DescriptorD3D12::CreateShaderResourceView(ID3D12Resource* resource, const
     m_DescriptorHandleCPU = m_Device.GetDescriptorHandleCPU(m_Handle);
 
 #if NRI_ENABLE_AGILITY_SDK_SUPPORT
-    HRESULT hr = m_Device->TryCreateShaderResourceView(resource, &desc, {m_DescriptorHandleCPU});
-    NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateShaderResourceView");
+    if (m_Device.GetVersion() >= 15) {
+        HRESULT hr = m_Device->TryCreateShaderResourceView(resource, &desc, {m_DescriptorHandleCPU});
+        NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateShaderResourceView");
+    } else
+        m_Device->CreateShaderResourceView(resource, &desc, {m_DescriptorHandleCPU});
 #else
     m_Device->CreateShaderResourceView(resource, &desc, {m_DescriptorHandleCPU});
 #endif
@@ -510,8 +538,11 @@ Result DescriptorD3D12::CreateUnorderedAccessView(ID3D12Resource* resource, cons
     m_DescriptorHandleCPU = m_Device.GetDescriptorHandleCPU(m_Handle);
 
 #if NRI_ENABLE_AGILITY_SDK_SUPPORT
-    HRESULT hr = m_Device->TryCreateUnorderedAccessView(resource, nullptr, &desc, {m_DescriptorHandleCPU});
-    NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateUnorderedAccessView");
+    if (m_Device.GetVersion() >= 15) {
+        HRESULT hr = m_Device->TryCreateUnorderedAccessView(resource, nullptr, &desc, {m_DescriptorHandleCPU});
+        NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateUnorderedAccessView");
+    } else
+        m_Device->CreateUnorderedAccessView(resource, nullptr, &desc, {m_DescriptorHandleCPU});
 #else
     m_Device->CreateUnorderedAccessView(resource, nullptr, &desc, {m_DescriptorHandleCPU});
 #endif
@@ -535,8 +566,11 @@ Result DescriptorD3D12::CreateRenderTargetView(ID3D12Resource* resource, const D
     m_DescriptorHandleCPU = m_Device.GetDescriptorHandleCPU(m_Handle);
 
 #if NRI_ENABLE_AGILITY_SDK_SUPPORT
-    HRESULT hr = m_Device->TryCreateRenderTargetView(resource, &desc, {m_DescriptorHandleCPU});
-    NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateRenderTargetView");
+    if (m_Device.GetVersion() >= 15) {
+        HRESULT hr = m_Device->TryCreateRenderTargetView(resource, &desc, {m_DescriptorHandleCPU});
+        NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateRenderTargetView");
+    } else
+        m_Device->CreateRenderTargetView(resource, &desc, {m_DescriptorHandleCPU});
 #else
     m_Device->CreateRenderTargetView(resource, &desc, {m_DescriptorHandleCPU});
 #endif
@@ -554,8 +588,11 @@ Result DescriptorD3D12::CreateDepthStencilView(ID3D12Resource* resource, const D
     m_DescriptorHandleCPU = m_Device.GetDescriptorHandleCPU(m_Handle);
 
 #if NRI_ENABLE_AGILITY_SDK_SUPPORT
-    HRESULT hr = m_Device->TryCreateDepthStencilView(resource, &desc, {m_DescriptorHandleCPU});
-    NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateDepthStencilView");
+    if (m_Device.GetVersion() >= 15) {
+        HRESULT hr = m_Device->TryCreateDepthStencilView(resource, &desc, {m_DescriptorHandleCPU});
+        NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D12Device15::TryCreateDepthStencilView");
+    } else
+        m_Device->CreateDepthStencilView(resource, &desc, {m_DescriptorHandleCPU});
 #else
     m_Device->CreateDepthStencilView(resource, &desc, {m_DescriptorHandleCPU});
 #endif

--- a/Source/D3D12/DeviceD3D12.hpp
+++ b/Source/D3D12/DeviceD3D12.hpp
@@ -32,7 +32,11 @@ static HRESULT QueryLatestInterface(ComPtr<ID3D12DeviceBest>& in, ComPtr<ID3D12D
 
     version = n - i - 1;
 
+#if NRI_ENABLE_AGILITY_SDK_SUPPORT
+    return i < n && version >= 10 ? S_OK : D3D12_ERROR_INVALID_REDIST;
+#else
     return i == 0 ? S_OK : D3D12_ERROR_INVALID_REDIST;
+#endif
 }
 
 static inline uint64_t HashRootSignatureAndStride(ID3D12RootSignature* rootSignature, uint32_t stride) {


### PR DESCRIPTION
## Summary

This changes the D3D12 Agility SDK path to tolerate runtimes that expose a lower D3D12 interface than the newest headers provide.

With Agility SDK headers that define `ID3D12Device15`, NRI currently treats any lower successful `QueryInterface` result as `D3D12_ERROR_INVALID_REDIST` for internally-created devices. On a system where the Agility runtime exposes `ID3D12Device14`, device creation fails even though the backend can continue using the lower interface.

I understand the solution is quite narrow. I can do more changes if needed.

## Changes

- Accept Agility D3D12 device interfaces down to `ID3D12Device10`, which is the minimum needed for the resource creation calls used in the Agility path.
- Accept Agility graphics command list interfaces down to `ID3D12GraphicsCommandList6`.
- Use the `ID3D12Device15::TryCreate*` descriptor entry points only when device 15 is actually available.
- Fall back to the legacy `Create*View` / `CreateSampler` descriptor creation calls on lower device interfaces.

## Validation

Validated in a downstream Windows integration with an NVIDIA GeForce RTX 5080 using NVIDIA driver 591.86, where the runtime reports `ID3D12Device14`:

- Before: device creation failed in `ID3D12Device::QueryLatestInterface()` with `D3D12_ERROR_INVALID_REDIST`.
- After: device creation succeeds and logs `Using ID3D12Device14`. The targetted software compiles and runs without problems with validation layers enabled.