### PR TITLE
D3D12: fix planar video texture plane selection

### DIFF
--- a/Source/D3D12/DescriptorD3D12.hpp
+++ b/Source/D3D12/DescriptorD3D12.hpp
@@ -15,16 +15,40 @@ static inline DXGI_FORMAT GetShaderFormatForDepth(DXGI_FORMAT format) {
     }
 }
 
-static inline uint32_t GetPlaneIndex(Format format) { // TODO: still unclear, is it needed for a stencil-only SRV?
+static inline uint32_t GetPlaneIndex(DXGI_FORMAT resourceFormat, Format viewFormat) { // TODO: still unclear, is it needed for a stencil-only SRV?
     // https://microsoft.github.io/DirectX-Specs/d3d/PlanarDepthStencilDDISpec.html
-    switch (format) {
+    switch (viewFormat) {
         case Format::X32_G8_UINT_X24:
         case Format::X24_G8_UINT:
             return 1;
 
         default:
-            return 0;
+            break;
     }
+
+    // NV12/P010/P016 expose luma in plane 0 and chroma in plane 1.
+    switch (resourceFormat) {
+        case DXGI_FORMAT_NV12:
+            if (viewFormat == Format::RG8_UNORM || viewFormat == Format::RG8_UINT)
+                return 1;
+            break;
+
+        case DXGI_FORMAT_P010:
+        case DXGI_FORMAT_P016:
+            if (viewFormat == Format::RG16_UNORM || viewFormat == Format::RG16_UINT || viewFormat == Format::R32_UINT)
+                return 1;
+            break;
+
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+static inline DXGI_FORMAT GetResourceFormat(const TextureD3D12& texture) {
+    ID3D12ResourceBest* resource = texture;
+    return resource->GetDesc().Format;
 }
 
 static inline uint32_t GetComponentSwizzle(ComponentSwizzle componentSwizzle, uint32_t channelIndex) {
@@ -58,6 +82,7 @@ static inline uint32_t GetComponentMapping(const ComponentMapping& componentMapp
 Result DescriptorD3D12::Create(const TextureViewDesc& textureViewDesc) {
     const TextureD3D12& textureD3D12 = *(TextureD3D12*)textureViewDesc.texture;
     const TextureDesc& textureDesc = textureD3D12.GetDesc();
+    const DXGI_FORMAT resourceFormat = GetResourceFormat(textureD3D12);
 
     DXGI_FORMAT format = GetDxgiFormat(textureViewDesc.format).typed;
     Dim_t mipNum = textureViewDesc.mipNum == REMAINING ? (textureDesc.mipNum - textureViewDesc.mipOffset) : textureViewDesc.mipNum;
@@ -157,7 +182,7 @@ Result DescriptorD3D12::Create(const TextureViewDesc& textureViewDesc) {
                     desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
                     desc.Texture2D.MostDetailedMip = textureViewDesc.mipOffset;
                     desc.Texture2D.MipLevels = mipNum;
-                    desc.Texture2D.PlaneSlice = GetPlaneIndex(textureViewDesc.format);
+                    desc.Texture2D.PlaneSlice = GetPlaneIndex(resourceFormat, textureViewDesc.format);
                 }
 
                 return CreateShaderResourceView(textureD3D12, desc);
@@ -176,7 +201,7 @@ Result DescriptorD3D12::Create(const TextureViewDesc& textureViewDesc) {
                     desc.Texture2DArray.MipLevels = mipNum;
                     desc.Texture2DArray.FirstArraySlice = textureViewDesc.layerOffset;
                     desc.Texture2DArray.ArraySize = layerNum;
-                    desc.Texture2DArray.PlaneSlice = GetPlaneIndex(textureViewDesc.format);
+                    desc.Texture2DArray.PlaneSlice = GetPlaneIndex(resourceFormat, textureViewDesc.format);
                 }
 
                 return CreateShaderResourceView(textureD3D12, desc);
@@ -208,7 +233,7 @@ Result DescriptorD3D12::Create(const TextureViewDesc& textureViewDesc) {
                 desc.Format = format;
                 desc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
                 desc.Texture2D.MipSlice = textureViewDesc.mipOffset;
-                desc.Texture2D.PlaneSlice = GetPlaneIndex(textureViewDesc.format);
+                desc.Texture2D.PlaneSlice = GetPlaneIndex(resourceFormat, textureViewDesc.format);
 
                 return CreateUnorderedAccessView(textureD3D12, desc);
             }
@@ -219,7 +244,7 @@ Result DescriptorD3D12::Create(const TextureViewDesc& textureViewDesc) {
                 desc.Texture2DArray.MipSlice = textureViewDesc.mipOffset;
                 desc.Texture2DArray.FirstArraySlice = textureViewDesc.layerOffset;
                 desc.Texture2DArray.ArraySize = layerNum;
-                desc.Texture2DArray.PlaneSlice = GetPlaneIndex(textureViewDesc.format);
+                desc.Texture2DArray.PlaneSlice = GetPlaneIndex(resourceFormat, textureViewDesc.format);
 
                 return CreateUnorderedAccessView(textureD3D12, desc);
             }
@@ -235,7 +260,7 @@ Result DescriptorD3D12::Create(const TextureViewDesc& textureViewDesc) {
                     desc.Texture2DArray.MipSlice = textureViewDesc.mipOffset;
                     desc.Texture2DArray.FirstArraySlice = textureViewDesc.layerOffset;
                     desc.Texture2DArray.ArraySize = layerNum;
-                    desc.Texture2DArray.PlaneSlice = GetPlaneIndex(textureViewDesc.format);
+                    desc.Texture2DArray.PlaneSlice = GetPlaneIndex(resourceFormat, textureViewDesc.format);
                 }
 
                 return CreateRenderTargetView(textureD3D12, desc);


### PR DESCRIPTION
## Summary
- Choose D3D12 SRV/UAV plane slices using the actual resource `DXGI_FORMAT` plus the requested NRI view format.
- Map NV12 luma/chroma views to plane 0/1, including UNORM and UINT view variants.
- Map P010/P016 luma/chroma views to plane 0/1, including `RG16_UINT` and the `R32_UINT` chroma UAV case.

## Motivation
D3D12 hardware video decode textures can use planar formats such as NV12, P010, and P016. The previous D3D12 descriptor code chose `PlaneSlice` mostly from the view format and otherwise defaulted to plane 0. That works for luma views, but chroma SRV/UAV descriptors could accidentally target plane 0 instead of plane 1.

This makes D3D12VA/video decode planar texture sampling work correctly by selecting the luma or chroma plane from the resource's native DXGI format and the requested typed view format.