### PR TITLE
Add graphics api param to nriEnumerateAdapters

### DIFF
--- a/Include/Extensions/NRIDeviceCreation.h
+++ b/Include/Extensions/NRIDeviceCreation.h
@@ -84,7 +84,7 @@ NriStruct(DeviceCreationDesc) {
 
 // if "adapterDescs == NULL", then "adapterDescNum" is set to the number of adapters
 // else "adapterDescNum" must be set to number of elements in "adapterDescs"
-NRI_API Nri(Result) NRI_CALL nriEnumerateAdapters(NriPtr(AdapterDesc) adapterDescs, NonNriRef(uint32_t) adapterDescNum);
+NRI_API Nri(Result) NRI_CALL nriEnumerateAdapters(Nri(GraphicsAPI) graphicsAPI, NriPtr(AdapterDesc) adapterDescs, NonNriRef(uint32_t) adapterDescNum);
 
 NRI_API Nri(Result) NRI_CALL nriCreateDevice(const NriRef(DeviceCreationDesc) deviceCreationDesc, NriOut NriRef(Device*) device);
 NRI_API void NRI_CALL nriDestroyDevice(NriPtr(Device) device);

--- a/Source/Creation/Creation.cpp
+++ b/Source/Creation/Creation.cpp
@@ -687,7 +687,7 @@ NRI_API Result NRI_CALL nriCreateDevice(const DeviceCreationDesc& deviceCreation
     uint32_t adapterDescNum = 1;
     AdapterDesc adapterDesc = {};
     if (!modifiedDeviceCreationDesc.adapterDesc) {
-        nriEnumerateAdapters(&adapterDesc, adapterDescNum);
+        nriEnumerateAdapters(modifiedDeviceCreationDesc.graphicsAPI, &adapterDesc, adapterDescNum);
         modifiedDeviceCreationDesc.adapterDesc = &adapterDesc;
     }
 
@@ -947,15 +947,21 @@ NRI_API const char* NRI_CALL nriGetGraphicsAPIString(GraphicsAPI graphicsAPI) {
     }
 }
 
-NRI_API Result NRI_CALL nriEnumerateAdapters(AdapterDesc* adapterDescs, uint32_t& adapterDescNum) {
+NRI_API Result NRI_CALL nriEnumerateAdapters(GraphicsAPI graphicsAPI, AdapterDesc* adapterDescs, uint32_t& adapterDescNum) {
     Result result = Result::UNSUPPORTED;
+    if (graphicsAPI == GraphicsAPI::NONE) {
+        return result;
+    }
 
     if (adapterDescs && adapterDescNum)
         memset(adapterDescs, 0, sizeof(AdapterDesc) * adapterDescNum);
 
 #if NRI_ENABLE_VK_SUPPORT
-    // Try VK first as capable to return real support for queues
-    result = EnumerateAdaptersVK(adapterDescs, adapterDescNum, 0, nullptr);
+    // Avoid using vulkan if D3D was explicitly requested to avoid unexpected behaviour
+    if (graphicsAPI == GraphicsAPI::VK) {
+        // Try VK first as capable to return real support for queues
+        result = EnumerateAdaptersVK(adapterDescs, adapterDescNum, 0, nullptr);
+    }
 #endif
 
 #if (NRI_ENABLE_D3D11_SUPPORT || NRI_ENABLE_D3D12_SUPPORT)


### PR DESCRIPTION
Added GraphicsAPI parameter to nriEnumerateAdapters to avoid the case where EnumerateAdaptersVK was used when D3D was requested, but failed when the System did not support Vulkan.

Example case: systems that do not have a gpu and use d3dwarp as fallback.