### PR TITLE
D3D11Fence: Fix fence failure for WDDM 1.x drivers

### DIFF
--- a/Source/D3D11/FenceD3D11.hpp
+++ b/Source/D3D11/FenceD3D11.hpp
@@ -6,12 +6,10 @@ Result FenceD3D11::Create(uint64_t initialValue) {
 
     if (m_Device.GetVersion() >= 5) {
         HRESULT hr = m_Device->CreateFence(initialValue, D3D11_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_Fence));
-        if (hr < 0) {
-            NRI_REPORT_WARNING(&m_Device, "ID3D11Device5::CreateFence() failed: result = 0x%08X (%d)!", hr, hr);
-        }
-    }
-
-    if (!m_Fence) {
+        if (hr < 0)
+            hr = m_Device->CreateFence(initialValue, D3D11_FENCE_FLAG_NON_MONITORED, IID_PPV_ARGS(&m_Fence));
+		NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D11Device5::CreateFence");
+    } else {
         D3D11_QUERY_DESC queryDesc = {};
         queryDesc.Query = D3D11_QUERY_EVENT;
 
@@ -62,16 +60,9 @@ NRI_INLINE void FenceD3D11::Wait(uint64_t value) {
             NRI_RETURN_ON_FAILURE(&m_Device, result == WAIT_OBJECT_0, ReturnVoid(), "WaitForSingleObjectEx() failed!");
         }
     } else if (m_Query) {
-        bool end = false;
         HRESULT hr = S_FALSE;
-        while (hr == S_FALSE) {
+        while (hr == S_FALSE)
             hr = m_Device.GetImmediateContext()->GetData(m_Query, nullptr, 0, 0);
-            if (!end && (hr == E_INVALIDARG || hr == DXGI_ERROR_INVALID_CALL)) {
-                m_Device.GetImmediateContext()->End(m_Query);
-                end = true;
-                hr = S_FALSE;
-            }
-        }
 
         NRI_RETURN_VOID_ON_BAD_HRESULT(&m_Device, hr, "D3D11DeviceContext::GetData");
     }

--- a/Source/D3D11/FenceD3D11.hpp
+++ b/Source/D3D11/FenceD3D11.hpp
@@ -6,8 +6,12 @@ Result FenceD3D11::Create(uint64_t initialValue) {
 
     if (m_Device.GetVersion() >= 5) {
         HRESULT hr = m_Device->CreateFence(initialValue, D3D11_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_Fence));
-        NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "ID3D11Device5::CreateFence");
-    } else {
+        if (hr < 0) {
+            NRI_REPORT_WARNING(&m_Device, "ID3D11Device5::CreateFence() failed: result = 0x%08X (%d)!", hr, hr);
+        }
+    }
+
+    if (!m_Fence) {
         D3D11_QUERY_DESC queryDesc = {};
         queryDesc.Query = D3D11_QUERY_EVENT;
 
@@ -58,9 +62,16 @@ NRI_INLINE void FenceD3D11::Wait(uint64_t value) {
             NRI_RETURN_ON_FAILURE(&m_Device, result == WAIT_OBJECT_0, ReturnVoid(), "WaitForSingleObjectEx() failed!");
         }
     } else if (m_Query) {
+        bool end = false;
         HRESULT hr = S_FALSE;
-        while (hr == S_FALSE)
+        while (hr == S_FALSE) {
             hr = m_Device.GetImmediateContext()->GetData(m_Query, nullptr, 0, 0);
+            if (!end && (hr == E_INVALIDARG || hr == DXGI_ERROR_INVALID_CALL)) {
+                m_Device.GetImmediateContext()->End(m_Query);
+                end = true;
+                hr = S_FALSE;
+            }
+        }
 
         NRI_RETURN_VOID_ON_BAD_HRESULT(&m_Device, hr, "D3D11DeviceContext::GetData");
     }


### PR DESCRIPTION
Example case: VMware SVGA 3D Driver

Curious driver behaviour?

Issue 1: Fences don't seem to work
> ERROR (FenceD3D11.hpp:9) - D3D11::VMware SVGA 3D - ID3D11Device5::CreateFence(): failed, result = 0x80070057 (-2147024809)!

Solution: Don't error, instead soft fallback to queries

Issue 2: GetImmediateContext()->End(m_Query) may fail without call to End()
> ERROR (FenceD3D11.hpp:76) - D3D11::VMware SVGA 3D - D3D11DeviceContext::GetData(): failed, result = 0x887A0001 (-2005270527)!

Workaround?: Call ->End after catching the first unexpected errors (E_INVALIDARG, DXGI_ERROR_INVALID_CALL)


Need feedback on these changes as they do fix the issues (I can use my project with my changes) but I'm not sure are correct.