### PR TITLE
"BufferDesc::structureStride" untangling

### DIFF
--- a/Include/NRIDescs.h
+++ b/Include/NRIDescs.h
@@ -690,17 +690,14 @@ NriStruct(TextureDesc) {
 };
 
 // - VK: buffers are always created with sharing mode "CONCURRENT" to match D3D12 spec
-// - "structureStride" values:
-//   - 0  - allows only "typed" views
-//          WGPU: typed buffer views are unsupported
-//   - 4  - allows "typed", "byte address" and "structured" views
-//          D3D11: allows to create multiple "structured" views for a single resource, disobeying the spec
-//   - >4 - allows only "structured" views
-//          D3D11: locks this buffer to a single "structured" layout
+// - D3D11: "structureStride != 0" locks this buffer to a single "STRUCTURED" layout, unless "byteAddress" is set to "true"
+// - D3D11: "byteAddress = true" allows to create multiple "STRUCTURED" views for a single resource by treating a "STRUCTURED" view as "BYTE_ADDRESS" (spec violation)
+// - WGPU: typed buffer views are unsupported (i.e. "structureStride = 0" and "byteAddress = false")
 NriStruct(BufferDesc) {
     uint64_t size;
-    uint32_t structureStride;
+    uint32_t structureStride;   // enable "STRUCTURED" views
     Nri(BufferUsageBits) usage;
+    bool byteAddress;           // enable "BYTE_ADDRESS" views
 };
 
 #pragma endregion

--- a/Source/D3D11/BufferD3D11.hpp
+++ b/Source/D3D11/BufferD3D11.hpp
@@ -23,14 +23,11 @@ Result BufferD3D11::Allocate(MemoryLocation memoryLocation, float priority) {
     D3D11_BUFFER_DESC desc = {};
     desc.ByteWidth = (uint32_t)m_Desc.size;
 
-    if (m_Desc.structureStride) {
-        if (m_Desc.structureStride == 4)
-            // It's a hack and spec violation, but allows to create multiple views with different "structured" layouts for a single buffer
-            desc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
-        else {
-            desc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
-            desc.StructureByteStride = m_Desc.structureStride;
-        }
+    if (m_Desc.byteAddress) // higher priority to allow "STRUCTURED" hacks
+        desc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
+    else if (m_Desc.structureStride) {
+        desc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+        desc.StructureByteStride = m_Desc.structureStride;
     }
 
     if (m_Desc.usage & BufferUsageBits::ARGUMENT_BUFFER)

--- a/Source/D3D11/DescriptorD3D11.hpp
+++ b/Source/D3D11/DescriptorD3D11.hpp
@@ -286,7 +286,7 @@ Result DescriptorD3D11::Create(const BufferViewDesc& bufferViewDesc) {
         if (bufferViewDesc.offset != 0 && m_Device.GetVersion() == 0)
             NRI_REPORT_ERROR(&m_Device, "Constant buffers with non-zero offsets require 11.1+ feature level!");
     } else if (bufferViewDesc.type == BufferView::STRUCTURED_BUFFER || bufferViewDesc.type == BufferView::STORAGE_STRUCTURED_BUFFER) {
-        if (structureStride != bufferDesc.structureStride || structureStride == 4) {
+        if (bufferDesc.byteAddress) {
             // D3D11 requires "structureStride" passed during creation, but we violate the spec and treat "structured" buffers as "raw" to allow multiple views creation for a single buffer // TODO: this may not work on some HW!
             patchedFormat = Format::R32_UINT;
             isRaw = true;

--- a/Source/VK/DeviceVK.hpp
+++ b/Source/VK/DeviceVK.hpp
@@ -17,53 +17,48 @@ static inline uint32_t NextPow2(uint32_t n) {
     return n;
 }
 
-static constexpr VkBufferUsageFlags GetBufferUsageFlags(BufferUsageBits bufferUsageBits, uint32_t structureStride, bool isDeviceAddressSupported) {
+static constexpr VkBufferUsageFlags GetBufferUsageFlags(const BufferDesc& bufferDesc, bool isDeviceAddressSupported) {
     VkBufferUsageFlags flags = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT; // TODO: ban "the opposite" for UPLOAD/READBACK?
 
     if (isDeviceAddressSupported)
         flags |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::VERTEX_BUFFER)
+    if (bufferDesc.usage & BufferUsageBits::VERTEX_BUFFER)
         flags |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::INDEX_BUFFER)
+    if (bufferDesc.usage & BufferUsageBits::INDEX_BUFFER)
         flags |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::CONSTANT_BUFFER)
+    if (bufferDesc.usage & BufferUsageBits::CONSTANT_BUFFER)
         flags |= VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::ARGUMENT_BUFFER)
+    if (bufferDesc.usage & BufferUsageBits::ARGUMENT_BUFFER)
         flags |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::SCRATCH_BUFFER)
+    bool isSSBO = bufferDesc.structureStride != 0 || bufferDesc.byteAddress; // so called SSBO, can be R/W in shaders
+    if ((bufferDesc.usage & BufferUsageBits::SCRATCH_BUFFER) || isSSBO)
         flags |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::SHADER_BINDING_TABLE)
+    if (bufferDesc.usage & BufferUsageBits::SHADER_BINDING_TABLE)
         flags |= VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR;
 
-    if (bufferUsageBits & BufferUsageBits::ACCELERATION_STRUCTURE_STORAGE)
+    if (bufferDesc.usage & BufferUsageBits::ACCELERATION_STRUCTURE_STORAGE)
         flags |= VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
 
-    if (bufferUsageBits & BufferUsageBits::ACCELERATION_STRUCTURE_BUILD_INPUT)
+    if (bufferDesc.usage & BufferUsageBits::ACCELERATION_STRUCTURE_BUILD_INPUT)
         flags |= VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR;
 
-    if (bufferUsageBits & BufferUsageBits::MICROMAP_STORAGE)
+    if (bufferDesc.usage & BufferUsageBits::MICROMAP_STORAGE)
         flags |= VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT;
 
-    if (bufferUsageBits & BufferUsageBits::MICROMAP_BUILD_INPUT)
+    if (bufferDesc.usage & BufferUsageBits::MICROMAP_BUILD_INPUT)
         flags |= VK_BUFFER_USAGE_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT;
 
-    // Based on comments for "BufferDesc::structureStride"
-    if (structureStride == 0 || structureStride == 4) {
-        if (bufferUsageBits & BufferUsageBits::SHADER_RESOURCE)
-            flags |= VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
+    if (bufferDesc.usage & BufferUsageBits::SHADER_RESOURCE)
+        flags |= VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
-        if (bufferUsageBits & BufferUsageBits::SHADER_RESOURCE_STORAGE)
-            flags |= VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
-    }
-
-    if (structureStride)
-        flags |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT; // so called SSBO, can be R/W in shaders
+    if (bufferDesc.usage & BufferUsageBits::SHADER_RESOURCE_STORAGE)
+        flags |= VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
 
     return flags;
 }
@@ -939,7 +934,7 @@ Result DeviceVK::Create(const DeviceCreationDesc& desc, const DeviceCreationVKDe
 
         m_Desc.memoryAlignment.uploadBufferTextureRow = (uint32_t)limits.optimalBufferCopyRowPitchAlignment;
         m_Desc.memoryAlignment.uploadBufferTextureSlice = std::lcm((uint32_t)limits.optimalBufferCopyOffsetAlignment, leastCommonMultipleStrideAccrossAllFormats);
-        m_Desc.memoryAlignment.bufferShaderResourceOffset = std::lcm((uint32_t)limits.minTexelBufferOffsetAlignment, (uint32_t)limits.minStorageBufferOffsetAlignment);
+        m_Desc.memoryAlignment.bufferShaderResourceOffset = std::lcm((uint32_t)limits.minTexelBufferOffsetAlignment, (uint32_t)limits.minStorageBufferOffsetAlignment); // see "GetBufferUsageFlags"
         m_Desc.memoryAlignment.constantBufferOffset = (uint32_t)limits.minUniformBufferOffsetAlignment;
         m_Desc.memoryAlignment.scratchBufferOffset = AccelerationStructureProps.minAccelerationStructureScratchOffsetAlignment;
         m_Desc.memoryAlignment.shaderBindingTable = RayTracingPipelineProps.shaderGroupBaseAlignment;
@@ -1242,7 +1237,7 @@ Result DeviceVK::Create(const DeviceCreationDesc& desc, const DeviceCreationVKDe
         m_Desc.shaderFeatures.rayTracingPositionFetch = RayTracingPositionFetchFeatures.rayTracingPositionFetch;
         m_Desc.shaderFeatures.integerDotProduct = features13.shaderIntegerDotProduct;
         m_Desc.shaderFeatures.inputAttachments = features14.dynamicRenderingLocalRead || !features13.dynamicRendering; // legacy render passes support "input attachments"
-        m_Desc.shaderFeatures.drawParameters = features11.shaderDrawParameters ? true : false; // TODO: emulation is not implemented, because >99% devices support it!
+        m_Desc.shaderFeatures.drawParameters = features11.shaderDrawParameters ? true : false;                         // TODO: emulation is not implemented, because >99% devices support it!
         m_Desc.shaderFeatures.drawIndex = m_Desc.shaderFeatures.drawParameters;
 
         // Estimate shader model last since it depends on many "m_Desc" fields
@@ -1281,7 +1276,7 @@ Result DeviceVK::Create(const DeviceCreationDesc& desc, const DeviceCreationVKDe
 void DeviceVK::FillCreateInfo(const BufferDesc& bufferDesc, VkBufferCreateInfo& info) const {
     info = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; // should be already set
     info.size = bufferDesc.size;
-    info.usage = GetBufferUsageFlags(bufferDesc.usage, bufferDesc.structureStride, m_IsSupported.deviceAddress);
+    info.usage = GetBufferUsageFlags(bufferDesc, m_IsSupported.deviceAddress);
     info.sharingMode = m_NumActiveFamilyIndices <= 1 ? VK_SHARING_MODE_EXCLUSIVE : VK_SHARING_MODE_CONCURRENT;
     info.queueFamilyIndexCount = m_NumActiveFamilyIndices;
     info.pQueueFamilyIndices = m_ActiveQueueFamilyIndices.data();


### PR DESCRIPTION
"structureStride" special values replaced with additional "byteAddress" field, what makes 4-byte structured buffers usable