### PR TITLE
Core: removed "_BUFFER" suffix from some "BufferUsageBits" to avoid "buffer-buffer"

### DIFF
--- a/Include/NRIDescs.h
+++ b/Include/NRIDescs.h
@@ -663,11 +663,11 @@ NriBits(BufferUsageBits, uint16_t,                  // Min compatible access:   
     NONE                                = 0,
     SHADER_RESOURCE                     = NriBit(0),    // SHADER_RESOURCE                          Read-only shader resource view (SRV)
     SHADER_RESOURCE_STORAGE             = NriBit(1),    // SHADER_RESOURCE_STORAGE                  Read/write shader resource view (UAV)
-    VERTEX_BUFFER                       = NriBit(2),    // VERTEX_BUFFER                            Vertex buffer
-    INDEX_BUFFER                        = NriBit(3),    // INDEX_BUFFER                             Index buffer
-    CONSTANT_BUFFER                     = NriBit(4),    // CONSTANT_BUFFER                          Constant buffer (D3D11: can't be combined with other usages)
-    ARGUMENT_BUFFER                     = NriBit(5),    // ARGUMENT_BUFFER                          Argument buffer in "Indirect" commands
-    SCRATCH_BUFFER                      = NriBit(6),    // SCRATCH_BUFFER                           Scratch buffer in "CmdBuild*" commands
+    VERTEX                              = NriBit(2),    // VERTEX_BUFFER                            Vertex buffer
+    INDEX                               = NriBit(3),    // INDEX_BUFFER                             Index buffer
+    CONSTANT                            = NriBit(4),    // CONSTANT_BUFFER                          Constant buffer (D3D11: can't be combined with other usages)
+    ARGUMENT                            = NriBit(5),    // ARGUMENT_BUFFER                          Argument buffer in "Indirect" commands
+    SCRATCH                             = NriBit(6),    // SCRATCH_BUFFER                           Scratch buffer in "CmdBuild*" commands
     SHADER_BINDING_TABLE                = NriBit(7),    // SHADER_BINDING_TABLE                     Shader binding table (SBT) in "CmdDispatchRays*" commands
     ACCELERATION_STRUCTURE_BUILD_INPUT  = NriBit(8),    // SHADER_RESOURCE                          Read-only input in "CmdBuildAccelerationStructures" command
     ACCELERATION_STRUCTURE_STORAGE      = NriBit(9),    // ACCELERATION_STRUCTURE_READ/WRITE        (INTERNAL) acceleration structure storage

--- a/Source/D3D11/BufferD3D11.hpp
+++ b/Source/D3D11/BufferD3D11.hpp
@@ -33,7 +33,7 @@ Result BufferD3D11::Allocate(MemoryLocation memoryLocation, float priority) {
         }
     }
 
-    if (m_Desc.usage & BufferUsageBits::ARGUMENT_BUFFER)
+    if (m_Desc.usage & BufferUsageBits::ARGUMENT)
         desc.MiscFlags |= D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS;
 
     if (memoryLocation == MemoryLocation::HOST_UPLOAD || memoryLocation == MemoryLocation::DEVICE_UPLOAD) {
@@ -52,13 +52,13 @@ Result BufferD3D11::Allocate(MemoryLocation memoryLocation, float priority) {
         desc.CPUAccessFlags = 0;
     }
 
-    if (m_Desc.usage & BufferUsageBits::VERTEX_BUFFER)
+    if (m_Desc.usage & BufferUsageBits::VERTEX)
         desc.BindFlags |= D3D11_BIND_VERTEX_BUFFER;
 
-    if (m_Desc.usage & BufferUsageBits::INDEX_BUFFER)
+    if (m_Desc.usage & BufferUsageBits::INDEX)
         desc.BindFlags |= D3D11_BIND_INDEX_BUFFER;
 
-    if (m_Desc.usage & BufferUsageBits::CONSTANT_BUFFER)
+    if (m_Desc.usage & BufferUsageBits::CONSTANT)
         desc.BindFlags |= D3D11_BIND_CONSTANT_BUFFER;
 
     if (m_Desc.usage & BufferUsageBits::SHADER_RESOURCE)

--- a/Source/D3D11/DeviceD3D11.hpp
+++ b/Source/D3D11/DeviceD3D11.hpp
@@ -631,7 +631,7 @@ void DeviceD3D11::InitializeAmdExt(AGSContext* agsContext, bool isImported) {
 }
 
 void DeviceD3D11::GetMemoryDesc(const BufferDesc& bufferDesc, MemoryLocation memoryLocation, MemoryDesc& memoryDesc) const {
-    const bool isConstantBuffer = (bufferDesc.usage & BufferUsageBits::CONSTANT_BUFFER) == (uint32_t)BufferUsageBits::CONSTANT_BUFFER;
+    const bool isConstantBuffer = (bufferDesc.usage & BufferUsageBits::CONSTANT) == (uint32_t)BufferUsageBits::CONSTANT;
 
     uint32_t alignment = 65536;
     if (isConstantBuffer)

--- a/Source/D3D11/SharedD3D11.hpp
+++ b/Source/D3D11/SharedD3D11.hpp
@@ -281,17 +281,17 @@ bool nri::GetBufferDesc(const BufferD3D11Desc& bufferD3D11Desc, BufferDesc& buff
     bufferDesc.structureStride = desc.StructureByteStride;
 
     if (desc.BindFlags & D3D11_BIND_VERTEX_BUFFER)
-        bufferDesc.usage |= BufferUsageBits::VERTEX_BUFFER;
+        bufferDesc.usage |= BufferUsageBits::VERTEX;
     if (desc.BindFlags & D3D11_BIND_INDEX_BUFFER)
-        bufferDesc.usage |= BufferUsageBits::INDEX_BUFFER;
+        bufferDesc.usage |= BufferUsageBits::INDEX;
     if (desc.BindFlags & D3D11_BIND_CONSTANT_BUFFER)
-        bufferDesc.usage |= BufferUsageBits::CONSTANT_BUFFER;
+        bufferDesc.usage |= BufferUsageBits::CONSTANT;
     if (desc.BindFlags & D3D11_BIND_SHADER_RESOURCE)
         bufferDesc.usage |= BufferUsageBits::SHADER_RESOURCE;
     if (desc.BindFlags & D3D11_BIND_UNORDERED_ACCESS)
         bufferDesc.usage |= BufferUsageBits::SHADER_RESOURCE_STORAGE;
     if (desc.MiscFlags & D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS)
-        bufferDesc.usage |= BufferUsageBits::ARGUMENT_BUFFER;
+        bufferDesc.usage |= BufferUsageBits::ARGUMENT;
 
     return true;
 }

--- a/Source/D3D12/DeviceD3D12.hpp
+++ b/Source/D3D12/DeviceD3D12.hpp
@@ -84,7 +84,7 @@ static void __stdcall NvapiMessageCallback(void* context, NVAPI_D3D12_RAYTRACING
 static D3D12_RESOURCE_FLAGS GetBufferFlags(BufferUsageBits bufferUsage) {
     D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE;
 
-    if (bufferUsage & (BufferUsageBits::SHADER_RESOURCE_STORAGE | BufferUsageBits::SCRATCH_BUFFER))
+    if (bufferUsage & (BufferUsageBits::SHADER_RESOURCE_STORAGE | BufferUsageBits::SCRATCH))
         flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
 
     if (bufferUsage & (BufferUsageBits::ACCELERATION_STRUCTURE_STORAGE | BufferUsageBits::MICROMAP_STORAGE)) {

--- a/Source/D3D12/SharedD3D12.hpp
+++ b/Source/D3D12/SharedD3D12.hpp
@@ -436,7 +436,7 @@ bool nri::GetBufferDesc(const BufferD3D12Desc& bufferD3D12Desc, BufferDesc& buff
     bufferDesc.structureStride = bufferD3D12Desc.structureStride;
 
     // There are almost no restrictions on usages in D3D12
-    bufferDesc.usage = BufferUsageBits::VERTEX_BUFFER | BufferUsageBits::INDEX_BUFFER | BufferUsageBits::CONSTANT_BUFFER | BufferUsageBits::ARGUMENT_BUFFER | BufferUsageBits::ACCELERATION_STRUCTURE_BUILD_INPUT;
+    bufferDesc.usage = BufferUsageBits::VERTEX | BufferUsageBits::INDEX | BufferUsageBits::CONSTANT | BufferUsageBits::ARGUMENT | BufferUsageBits::ACCELERATION_STRUCTURE_BUILD_INPUT;
 
     if (!(desc.Flags & D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE))
         bufferDesc.usage |= BufferUsageBits::SHADER_RESOURCE;

--- a/Source/Shared/StreamerInterface.hpp
+++ b/Source/Shared/StreamerInterface.hpp
@@ -35,7 +35,7 @@ Result StreamerImpl::Create(const StreamerDesc& desc) {
         // Create the constant buffer
         BufferDesc bufferDesc = {};
         bufferDesc.size = desc.constantBufferSize;
-        bufferDesc.usage = BufferUsageBits::CONSTANT_BUFFER;
+        bufferDesc.usage = BufferUsageBits::CONSTANT;
 
         Result result = m_iCore.CreateCommittedBuffer(m_Device, desc.constantBufferMemoryLocation, 0.0f, bufferDesc, m_ConstantBuffer);
         if (result != Result::SUCCESS)

--- a/Source/VK/BufferVK.hpp
+++ b/Source/VK/BufferVK.hpp
@@ -145,7 +145,7 @@ void BufferVK::GetMemoryDesc(MemoryLocation memoryLocation, MemoryDesc& memoryDe
     vk.GetBufferMemoryRequirements2(m_Device, &bufferMemoryRequirements, &requirements);
 
     // There is no "VK_BUFFER_USAGE" flag for "SCRATCH_BUFFER", thus "vkGetBufferMemoryRequirements" can't return proper alignment. It affects memory "sub-allocation"
-    if (m_Desc.usage & BufferUsageBits::SCRATCH_BUFFER) {
+    if (m_Desc.usage & BufferUsageBits::SCRATCH) {
         VkDeviceSize scratchBufferOffset = m_Device.GetDesc().memoryAlignment.scratchBufferOffset;
         requirements.memoryRequirements.alignment = std::max(requirements.memoryRequirements.alignment, scratchBufferOffset);
     }

--- a/Source/VK/DeviceVK.hpp
+++ b/Source/VK/DeviceVK.hpp
@@ -23,19 +23,19 @@ static constexpr VkBufferUsageFlags GetBufferUsageFlags(BufferUsageBits bufferUs
     if (isDeviceAddressSupported)
         flags |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::VERTEX_BUFFER)
+    if (bufferUsageBits & BufferUsageBits::VERTEX)
         flags |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::INDEX_BUFFER)
+    if (bufferUsageBits & BufferUsageBits::INDEX)
         flags |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::CONSTANT_BUFFER)
+    if (bufferUsageBits & BufferUsageBits::CONSTANT)
         flags |= VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::ARGUMENT_BUFFER)
+    if (bufferUsageBits & BufferUsageBits::ARGUMENT)
         flags |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
 
-    if (bufferUsageBits & BufferUsageBits::SCRATCH_BUFFER)
+    if (bufferUsageBits & BufferUsageBits::SCRATCH)
         flags |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
     if (bufferUsageBits & BufferUsageBits::SHADER_BINDING_TABLE)

--- a/Source/Validation/CommandBufferVal.hpp
+++ b/Source/Validation/CommandBufferVal.hpp
@@ -3,15 +3,15 @@
 static inline bool IsAccessMaskSupported(const BufferDesc& bufferDesc, AccessBits accessMask) {
     bool isSupported = true;
     if (accessMask & AccessBits::INDEX_BUFFER)
-        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::INDEX_BUFFER) != 0;
+        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::INDEX) != 0;
     if (accessMask & AccessBits::VERTEX_BUFFER)
-        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::VERTEX_BUFFER) != 0;
+        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::VERTEX) != 0;
     if (accessMask & AccessBits::CONSTANT_BUFFER)
-        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::CONSTANT_BUFFER) != 0;
+        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::CONSTANT) != 0;
     if (accessMask & AccessBits::ARGUMENT_BUFFER)
-        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::ARGUMENT_BUFFER) != 0;
+        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::ARGUMENT) != 0;
     if (accessMask & AccessBits::SCRATCH_BUFFER)
-        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::SCRATCH_BUFFER) != 0;
+        isSupported = isSupported && (bufferDesc.usage & BufferUsageBits::SCRATCH) != 0;
     if (accessMask & (AccessBits::COLOR_ATTACHMENT | AccessBits::DEPTH_STENCIL_ATTACHMENT | AccessBits::SHADING_RATE_ATTACHMENT | AccessBits::INPUT_ATTACHMENT))
         isSupported = false;
     if (accessMask & AccessBits::ACCELERATION_STRUCTURE)

--- a/Source/WGPU/SharedWGPU.hpp
+++ b/Source/WGPU/SharedWGPU.hpp
@@ -275,15 +275,15 @@ WGPUTextureUsage nri::GetTextureUsage(TextureUsageBits usage) {
 WGPUBufferUsage nri::GetBufferUsage(BufferUsageBits usage) {
     WGPUBufferUsage result = WGPUBufferUsage_CopySrc | WGPUBufferUsage_CopyDst | WGPUBufferUsage_QueryResolve;
 
-    if (usage & BufferUsageBits::VERTEX_BUFFER)
+    if (usage & BufferUsageBits::VERTEX)
         result |= WGPUBufferUsage_Vertex;
-    if (usage & BufferUsageBits::INDEX_BUFFER)
+    if (usage & BufferUsageBits::INDEX)
         result |= WGPUBufferUsage_Index;
-    if (usage & BufferUsageBits::CONSTANT_BUFFER)
+    if (usage & BufferUsageBits::CONSTANT)
         result |= WGPUBufferUsage_Uniform;
     if (usage & (BufferUsageBits::SHADER_RESOURCE | BufferUsageBits::SHADER_RESOURCE_STORAGE))
         result |= WGPUBufferUsage_Storage;
-    if (usage & BufferUsageBits::ARGUMENT_BUFFER)
+    if (usage & BufferUsageBits::ARGUMENT)
         result |= WGPUBufferUsage_Indirect;
 
     return result;


### PR DESCRIPTION
It's in line with other `BufferUsageBits` and `TextureUsageBits`.