### PR TITLE
Helper: added "vma" to "ResourceGroupDesc"

### DIFF
--- a/Include/Extensions/NRIHelper.h
+++ b/Include/Extensions/NRIHelper.h
@@ -40,7 +40,8 @@ NriStruct(ResourceGroupDesc) {
     NriPtr(Buffer) const* buffers;
     uint32_t bufferNum;
     NriOptional uint64_t preferredMemorySize; // desired chunk size (but can be greater if a resource doesn't fit), 256 Mb if 0
-    NriOptional float residencyPriority; // [-1; 1]: low < 0, normal = 0, high > 0
+    NriOptional float residencyPriority;      // [-1; 1]: low < 0, normal = 0, high > 0
+    NriOptional bool vma;                     // memory allocation goes through "AMD Virtual Memory Allocator"
 };
 
 NriStruct(FormatProps) {

--- a/Source/D3D12/DeviceD3D12.hpp
+++ b/Source/D3D12/DeviceD3D12.hpp
@@ -1280,10 +1280,8 @@ void DeviceD3D12::GetMemoryDesc(MemoryLocation memoryLocation, const D3D12_RESOU
             heapFlags = D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES;
     }
 
-    // Not "1" - "offset" is not needed (we always pass 1 resource, not an array)
-    // Not "2" - "D3D12_RESOURCE_DESC1" is not in use
-    // Not "3" - no castable formats
-    D3D12_RESOURCE_ALLOCATION_INFO resourceAllocationInfo = m_Device->GetResourceAllocationInfo(NODE_MASK, 1, (D3D12_RESOURCE_DESC*)&resourceDesc);
+    D3D12_RESOURCE_ALLOCATION_INFO1 resourceAllocationInfo1 = {};
+    D3D12_RESOURCE_ALLOCATION_INFO resourceAllocationInfo = m_Device->GetResourceAllocationInfo2(NODE_MASK, 1, &resourceDesc, &resourceAllocationInfo1);
     NRI_CHECK(resourceAllocationInfo.SizeInBytes != UINT64_MAX, "Invalid arg?");
 
     MemoryTypeInfo memoryTypeInfo = {};

--- a/Source/D3D12/DeviceD3D12.hpp
+++ b/Source/D3D12/DeviceD3D12.hpp
@@ -1280,8 +1280,10 @@ void DeviceD3D12::GetMemoryDesc(MemoryLocation memoryLocation, const D3D12_RESOU
             heapFlags = D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES;
     }
 
-    D3D12_RESOURCE_ALLOCATION_INFO1 resourceAllocationInfo1 = {};
-    D3D12_RESOURCE_ALLOCATION_INFO resourceAllocationInfo = m_Device->GetResourceAllocationInfo2(NODE_MASK, 1, &resourceDesc, &resourceAllocationInfo1);
+    // Not "1" - "offset" is not needed (we always pass 1 resource, not an array)
+    // Not "2" - "D3D12_RESOURCE_DESC1" is not in use
+    // Not "3" - no castable formats
+    D3D12_RESOURCE_ALLOCATION_INFO resourceAllocationInfo = m_Device->GetResourceAllocationInfo(NODE_MASK, 1, (D3D12_RESOURCE_DESC*)&resourceDesc);
     NRI_CHECK(resourceAllocationInfo.SizeInBytes != UINT64_MAX, "Invalid arg?");
 
     MemoryTypeInfo memoryTypeInfo = {};

--- a/Source/Shared/HelperInterface.h
+++ b/Source/Shared/HelperInterface.h
@@ -49,6 +49,7 @@ private:
         Vector<Texture*> textures;
         Vector<uint64_t> textureOffsets;
         uint64_t size;
+        uint32_t alignment;
         MemoryType type;
     };
 

--- a/Source/Shared/HelperInterface.hpp
+++ b/Source/Shared/HelperInterface.hpp
@@ -438,6 +438,8 @@ Result HelperDeviceMemoryAllocator::TryToAllocateAndBindMemory(const ResourceGro
         allocateMemoryDesc.size = heap.size;
         allocateMemoryDesc.allowMultisampleTextures = hasMultisampleTextures;
         allocateMemoryDesc.priority = resourceGroupDesc.residencyPriority;
+        allocateMemoryDesc.vma.enable = resourceGroupDesc.vma;
+        allocateMemoryDesc.vma.alignment = heap.alignment;
 
         Result result = m_iCore.AllocateMemory(m_Device, allocateMemoryDesc, memory);
         if (result != Result::SUCCESS)
@@ -592,6 +594,7 @@ void HelperDeviceMemoryAllocator::GroupByMemoryType(MemoryLocation memoryLocatio
             heap.buffers.push_back(buffer);
             heap.bufferOffsets.push_back(offset);
             heap.size = offset + memoryDesc.size;
+            heap.alignment = std::max(heap.alignment, memoryDesc.alignment);
         }
     }
 
@@ -614,28 +617,29 @@ void HelperDeviceMemoryAllocator::GroupByMemoryType(MemoryLocation memoryLocatio
             heap.textures.push_back(texture);
             heap.textureOffsets.push_back(offset);
             heap.size = offset + memoryDesc.size;
+            heap.alignment = std::max(heap.alignment, memoryDesc.alignment);
         }
     }
 }
 
 void HelperDeviceMemoryAllocator::FillMemoryBindingDescs(Buffer* const* buffers, const uint64_t* bufferOffsets, uint32_t bufferNum, Memory& memory) {
+    m_BufferBindingDescs.reserve(m_BufferBindingDescs.size() + bufferNum);
+
     for (uint32_t i = 0; i < bufferNum; i++) {
-        BindBufferMemoryDesc desc = {};
+        BindBufferMemoryDesc& desc = m_BufferBindingDescs.emplace_back();
         desc.memory = &memory;
         desc.buffer = buffers[i];
         desc.offset = bufferOffsets[i];
-
-        m_BufferBindingDescs.push_back(desc);
     }
 }
 
 void HelperDeviceMemoryAllocator::FillMemoryBindingDescs(Texture* const* textures, const uint64_t* textureOffsets, uint32_t textureNum, Memory& memory) {
+    m_TextureBindingDescs.reserve(m_TextureBindingDescs.size() + textureNum);
+
     for (uint32_t i = 0; i < textureNum; i++) {
-        BindTextureMemoryDesc desc = {};
+        BindTextureMemoryDesc& desc = m_TextureBindingDescs.emplace_back();
         desc.memory = &memory;
         desc.texture = textures[i];
         desc.offset = textureOffsets[i];
-
-        m_TextureBindingDescs.push_back(desc);
     }
 }


### PR DESCRIPTION
This unlocks optional VMA usage in `AllocateMemoryDesc`.