### PR TITLE
Make presentation IDs application-owned

### DIFF
--- a/Include/Extensions/NRILowLatency.h
+++ b/Include/Extensions/NRILowLatency.h
@@ -44,12 +44,12 @@ NriStruct(LatencyReport) {          // The time stamp written:
 };
 
 // Multi-swapchain is supported only by VK
-// "QueueSubmitDesc::swapChain" must be used to associate work submission with a low latency swap chain
-// Threadsafe: no
+// "presentId" must be non-zero and match the value passed to "QueueSubmit" and "QueuePresent" for the frame
+// Threadsafe: yes
 NriStruct(LowLatencyInterface) {
     Nri(Result)     (NRI_CALL   *SetLatencySleepMode)   (NriRef(SwapChain) swapChain, const NriRef(LatencySleepMode) latencySleepMode);
-    Nri(Result)     (NRI_CALL   *SetLatencyMarker)      (NriRef(SwapChain) swapChain, Nri(LatencyMarker) latencyMarker);
-    Nri(Result)     (NRI_CALL   *LatencySleep)          (NriRef(SwapChain) swapChain); // call once before "INPUT_SAMPLE"
+    Nri(Result)     (NRI_CALL   *SetLatencyMarker)      (NriRef(SwapChain) swapChain, uint64_t presentId, Nri(LatencyMarker) latencyMarker);
+    Nri(Result)     (NRI_CALL   *LatencySleep)          (NriRef(SwapChain) swapChain, uint64_t presentId); // call once before "INPUT_SAMPLE"
     Nri(Result)     (NRI_CALL   *GetLatencyReport)      (const NriRef(SwapChain) swapChain, NriOut NriRef(LatencyReport) latencyReport);
 };
 

--- a/Include/Extensions/NRISwapChain.h
+++ b/Include/Extensions/NRISwapChain.h
@@ -132,8 +132,12 @@ NriStruct(SwapChainInterface) {
 
     // VK only: may return "OUT_OF_DATE", fences must be created with "SWAPCHAIN_SEMAPHORE" initial value
     Nri(Result)             (NRI_CALL *AcquireNextTexture)      (NriRef(SwapChain) swapChain, NriRef(Fence) acquireSemaphore, NriOut NonNriRef(uint32_t) textureIndex);
-    Nri(Result)             (NRI_CALL *WaitForPresent)          (NriRef(SwapChain) swapChain); // call once right before input sampling (must be called starting from the 1st frame)
-    Nri(Result)             (NRI_CALL *QueuePresent)            (NriRef(SwapChain) swapChain, NriRef(Fence) releaseSemaphore);
+    // "presentId" must identify a previously queued presentation
+    Nri(Result)             (NRI_CALL *WaitForPresent)          (NriRef(SwapChain) swapChain, uint64_t presentId); // call once right before input sampling
+
+    // A non-zero "presentId" must be greater than any non-zero value previously passed for the same swap chain
+    // 0 explicitly marks a presentation that is not associated with a tracked application frame
+    Nri(Result)             (NRI_CALL *QueuePresent)            (NriRef(SwapChain) swapChain, NriRef(Fence) releaseSemaphore, uint64_t presentId);
 };
 
 /*
@@ -203,7 +207,7 @@ Typical usage example, valid if the number of swap chain images >= queued frames
         NRI.QueueSubmit(queue, queueSubmitDesc);
 
     // Present
-        NRI.QueuePresent(swapChain, *releaseSemaphore);
+        NRI.QueuePresent(swapChain, *releaseSemaphore, 1 + frameIndex);
 */
 
 NriNamespaceEnd

--- a/Include/NRIDescs.h
+++ b/Include/NRIDescs.h
@@ -1730,6 +1730,7 @@ NriStruct(QueueSubmitDesc) {
     const NriPtr(FenceSubmitDesc) signalFences;
     uint32_t signalFenceNum;
     NriOptional const NriPtr(SwapChain) swapChain; // required if "NRILowLatency" is enabled in the swap chain
+    uint64_t presentId;                            // must match the value passed to "QueuePresent" if "swapChain" is not NULL
 };
 
 // Clear

--- a/Source/D3D11/ImplD3D11.cpp
+++ b/Source/D3D11/ImplD3D11.cpp
@@ -1022,12 +1022,12 @@ static Result NRI_CALL SetLatencySleepMode(SwapChain& swapChain, const LatencySl
     return ((SwapChainD3D11&)swapChain).SetLatencySleepMode(latencySleepMode);
 }
 
-static Result NRI_CALL SetLatencyMarker(SwapChain& swapChain, LatencyMarker latencyMarker) {
-    return ((SwapChainD3D11&)swapChain).SetLatencyMarker(latencyMarker);
+static Result NRI_CALL SetLatencyMarker(SwapChain& swapChain, uint64_t presentId, LatencyMarker latencyMarker) {
+    return ((SwapChainD3D11&)swapChain).SetLatencyMarker(presentId, latencyMarker);
 }
 
-static Result NRI_CALL LatencySleep(SwapChain& swapChain) {
-    return ((SwapChainD3D11&)swapChain).LatencySleep();
+static Result NRI_CALL LatencySleep(SwapChain& swapChain, uint64_t presentId) {
+    return ((SwapChainD3D11&)swapChain).LatencySleep(presentId);
 }
 
 static Result NRI_CALL GetLatencyReport(const SwapChain& swapChain, LatencyReport& latencyReport) {
@@ -1131,12 +1131,12 @@ static Result NRI_CALL AcquireNextTexture(SwapChain& swapChain, Fence&, uint32_t
     return ((SwapChainD3D11&)swapChain).AcquireNextTexture(textureIndex);
 }
 
-static Result NRI_CALL WaitForPresent(SwapChain& swapChain) {
-    return ((SwapChainD3D11&)swapChain).WaitForPresent();
+static Result NRI_CALL WaitForPresent(SwapChain& swapChain, uint64_t presentId) {
+    return ((SwapChainD3D11&)swapChain).WaitForPresent(presentId);
 }
 
-static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence&) {
-    return ((SwapChainD3D11&)swapChain).Present();
+static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence&, uint64_t presentId) {
+    return ((SwapChainD3D11&)swapChain).Present(presentId);
 }
 
 Result DeviceD3D11::FillFunctionTable(SwapChainInterface& table) const {

--- a/Source/D3D11/SwapChainD3D11.h
+++ b/Source/D3D11/SwapChainD3D11.h
@@ -38,12 +38,12 @@ struct SwapChainD3D11 final : public DisplayDescHelper, DebugNameBase {
 
     Texture* const* GetTextures(uint32_t& textureNum) const;
     Result AcquireNextTexture(uint32_t& textureIndex);
-    Result WaitForPresent();
-    Result Present();
+    Result WaitForPresent(uint64_t presentId);
+    Result Present(uint64_t presentId);
 
     Result SetLatencySleepMode(const LatencySleepMode& latencySleepMode);
-    Result SetLatencyMarker(LatencyMarker latencyMarker);
-    Result LatencySleep();
+    Result SetLatencyMarker(uint64_t presentId, LatencyMarker latencyMarker);
+    Result LatencySleep(uint64_t presentId);
     Result GetLatencyReport(LatencyReport& latencyReport);
 
 private:
@@ -52,7 +52,6 @@ private:
     TextureD3D11* m_Texture = nullptr;
     HANDLE m_FrameLatencyWaitableObject = nullptr;
     void* m_Hwnd = nullptr;
-    uint64_t m_PresentId = 0;
     uint8_t m_Version = 0;
     SwapChainBits m_Flags = SwapChainBits::NONE;
 };

--- a/Source/D3D11/SwapChainD3D11.hpp
+++ b/Source/D3D11/SwapChainD3D11.hpp
@@ -157,8 +157,6 @@ Result SwapChainD3D11::Create(const SwapChainDesc& swapChainDesc) {
 
     // Finalize
     m_Hwnd = swapChainDesc.window.windows.hwnd;
-    m_PresentId = GetSwapChainId();
-
     m_Flags = swapChainDesc.flags;
     if (!m_Device.HasNvExt())
         m_Flags &= ~SwapChainBits::ALLOW_LOW_LATENCY;
@@ -182,7 +180,9 @@ NRI_INLINE Result SwapChainD3D11::AcquireNextTexture(uint32_t& textureIndex) {
     return Result::SUCCESS;
 }
 
-NRI_INLINE Result SwapChainD3D11::WaitForPresent() {
+NRI_INLINE Result SwapChainD3D11::WaitForPresent(uint64_t presentId) {
+    MaybeUnused(presentId);
+
     if (m_FrameLatencyWaitableObject) {
         uint32_t result = WaitForSingleObjectEx(m_FrameLatencyWaitableObject, NRI_TIMEOUT_PRESENT, TRUE);
 
@@ -192,10 +192,12 @@ NRI_INLINE Result SwapChainD3D11::WaitForPresent() {
     return Result::UNSUPPORTED;
 }
 
-NRI_INLINE Result SwapChainD3D11::Present() {
+NRI_INLINE Result SwapChainD3D11::Present(uint64_t presentId) {
+    MaybeUnused(presentId);
+
 #if NRI_ENABLE_NVAPI
-    if (m_Flags & SwapChainBits::ALLOW_LOW_LATENCY)
-        SetLatencyMarker((LatencyMarker)PRESENT_START);
+    if ((m_Flags & SwapChainBits::ALLOW_LOW_LATENCY) && presentId != 0)
+        SetLatencyMarker(presentId, (LatencyMarker)PRESENT_START);
 #endif
 
     bool vsync = (m_Flags & SwapChainBits::VSYNC) != 0;
@@ -205,11 +207,9 @@ NRI_INLINE Result SwapChainD3D11::Present() {
     NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "IDXGISwapChain::Present");
 
 #if NRI_ENABLE_NVAPI
-    if (m_Flags & SwapChainBits::ALLOW_LOW_LATENCY)
-        SetLatencyMarker((LatencyMarker)PRESENT_END);
+    if ((m_Flags & SwapChainBits::ALLOW_LOW_LATENCY) && presentId != 0)
+        SetLatencyMarker(presentId, (LatencyMarker)PRESENT_END);
 #endif
-
-    m_PresentId++;
 
     return Result::SUCCESS;
 }
@@ -232,23 +232,26 @@ NRI_INLINE Result SwapChainD3D11::SetLatencySleepMode(const LatencySleepMode& la
 #endif
 }
 
-NRI_INLINE Result SwapChainD3D11::SetLatencyMarker(LatencyMarker latencyMarker) {
+NRI_INLINE Result SwapChainD3D11::SetLatencyMarker(uint64_t presentId, LatencyMarker latencyMarker) {
 #if NRI_ENABLE_NVAPI
     NV_LATENCY_MARKER_PARAMS params = {NV_LATENCY_MARKER_PARAMS_VER};
-    params.frameID = m_PresentId;
+    params.frameID = presentId;
     params.markerType = (NV_LATENCY_MARKER_TYPE)latencyMarker;
 
     NvAPI_Status status = NvAPI_D3D_SetLatencyMarker(m_Device.GetNativeObject(), &params);
 
     return status == NVAPI_OK ? Result::SUCCESS : Result::FAILURE;
 #else
+    MaybeUnused(presentId);
     MaybeUnused(latencyMarker);
 
     return Result::UNSUPPORTED;
 #endif
 }
 
-NRI_INLINE Result SwapChainD3D11::LatencySleep() {
+NRI_INLINE Result SwapChainD3D11::LatencySleep(uint64_t presentId) {
+    MaybeUnused(presentId);
+
 #if NRI_ENABLE_NVAPI
     NvAPI_Status status = NvAPI_D3D_Sleep(m_Device.GetNativeObject());
 

--- a/Source/D3D12/ImplD3D12.cpp
+++ b/Source/D3D12/ImplD3D12.cpp
@@ -840,12 +840,12 @@ static Result NRI_CALL SetLatencySleepMode(SwapChain& swapChain, const LatencySl
     return ((SwapChainD3D12&)swapChain).SetLatencySleepMode(latencySleepMode);
 }
 
-static Result NRI_CALL SetLatencyMarker(SwapChain& swapChain, LatencyMarker latencyMarker) {
-    return ((SwapChainD3D12&)swapChain).SetLatencyMarker(latencyMarker);
+static Result NRI_CALL SetLatencyMarker(SwapChain& swapChain, uint64_t presentId, LatencyMarker latencyMarker) {
+    return ((SwapChainD3D12&)swapChain).SetLatencyMarker(presentId, latencyMarker);
 }
 
-static Result NRI_CALL LatencySleep(SwapChain& swapChain) {
-    return ((SwapChainD3D12&)swapChain).LatencySleep();
+static Result NRI_CALL LatencySleep(SwapChain& swapChain, uint64_t presentId) {
+    return ((SwapChainD3D12&)swapChain).LatencySleep(presentId);
 }
 
 static Result NRI_CALL GetLatencyReport(const SwapChain& swapChain, LatencyReport& latencyReport) {
@@ -1225,12 +1225,12 @@ static Result NRI_CALL AcquireNextTexture(SwapChain& swapChain, Fence&, uint32_t
     return ((SwapChainD3D12&)swapChain).AcquireNextTexture(textureIndex);
 }
 
-static Result NRI_CALL WaitForPresent(SwapChain& swapChain) {
-    return ((SwapChainD3D12&)swapChain).WaitForPresent();
+static Result NRI_CALL WaitForPresent(SwapChain& swapChain, uint64_t presentId) {
+    return ((SwapChainD3D12&)swapChain).WaitForPresent(presentId);
 }
 
-static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence&) {
-    return ((SwapChainD3D12&)swapChain).Present();
+static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence&, uint64_t presentId) {
+    return ((SwapChainD3D12&)swapChain).Present(presentId);
 }
 
 Result DeviceD3D12::FillFunctionTable(SwapChainInterface& table) const {

--- a/Source/D3D12/SwapChainD3D12.h
+++ b/Source/D3D12/SwapChainD3D12.h
@@ -39,12 +39,12 @@ struct SwapChainD3D12 final : public DisplayDescHelper, DebugNameBase {
 
     Texture* const* GetTextures(uint32_t& textureNum) const;
     Result AcquireNextTexture(uint32_t& textureIndex);
-    Result WaitForPresent();
-    Result Present();
+    Result WaitForPresent(uint64_t presentId);
+    Result Present(uint64_t presentId);
 
     Result SetLatencySleepMode(const LatencySleepMode& latencySleepMode);
-    Result SetLatencyMarker(LatencyMarker latencyMarker);
-    Result LatencySleep();
+    Result SetLatencyMarker(uint64_t presentId, LatencyMarker latencyMarker);
+    Result LatencySleep(uint64_t presentId);
     Result GetLatencyReport(LatencyReport& latencyReport);
 
 private:
@@ -53,7 +53,6 @@ private:
     Vector<TextureD3D12*> m_Textures;
     HANDLE m_FrameLatencyWaitableObject = nullptr;
     void* m_Hwnd = nullptr;
-    uint64_t m_PresentId = 0;
     uint8_t m_Version = 0;
     SwapChainBits m_Flags = SwapChainBits::NONE;
 };

--- a/Source/D3D12/SwapChainD3D12.hpp
+++ b/Source/D3D12/SwapChainD3D12.hpp
@@ -164,8 +164,6 @@ Result SwapChainD3D12::Create(const SwapChainDesc& swapChainDesc) {
 
     // Finalize
     m_Hwnd = swapChainDesc.window.windows.hwnd;
-    m_PresentId = GetSwapChainId();
-
     m_Flags = swapChainDesc.flags;
     if (!m_Device.HasNvExt())
         m_Flags &= ~SwapChainBits::ALLOW_LOW_LATENCY;
@@ -193,7 +191,9 @@ NRI_INLINE Result SwapChainD3D12::AcquireNextTexture(uint32_t& textureIndex) {
     return Result::SUCCESS;
 }
 
-NRI_INLINE Result SwapChainD3D12::WaitForPresent() {
+NRI_INLINE Result SwapChainD3D12::WaitForPresent(uint64_t presentId) {
+    MaybeUnused(presentId);
+
     if (m_FrameLatencyWaitableObject) {
         // Is device lost?
         HRESULT hr = m_Device->GetDeviceRemovedReason() == S_OK ? S_OK : DXGI_ERROR_DEVICE_REMOVED;
@@ -207,10 +207,12 @@ NRI_INLINE Result SwapChainD3D12::WaitForPresent() {
     return Result::UNSUPPORTED;
 }
 
-NRI_INLINE Result SwapChainD3D12::Present() {
+NRI_INLINE Result SwapChainD3D12::Present(uint64_t presentId) {
+    MaybeUnused(presentId);
+
 #if NRI_ENABLE_NVAPI
-    if (m_Flags & SwapChainBits::ALLOW_LOW_LATENCY)
-        SetLatencyMarker((LatencyMarker)PRESENT_START);
+    if ((m_Flags & SwapChainBits::ALLOW_LOW_LATENCY) && presentId != 0)
+        SetLatencyMarker(presentId, (LatencyMarker)PRESENT_START);
 #endif
 
     bool vsync = (m_Flags & SwapChainBits::VSYNC) != 0;
@@ -220,11 +222,9 @@ NRI_INLINE Result SwapChainD3D12::Present() {
     NRI_RETURN_ON_BAD_HRESULT(&m_Device, hr, "IDXGISwapChain::Present");
 
 #if NRI_ENABLE_NVAPI
-    if (m_Flags & SwapChainBits::ALLOW_LOW_LATENCY)
-        SetLatencyMarker((LatencyMarker)PRESENT_END);
+    if ((m_Flags & SwapChainBits::ALLOW_LOW_LATENCY) && presentId != 0)
+        SetLatencyMarker(presentId, (LatencyMarker)PRESENT_END);
 #endif
-
-    m_PresentId++;
 
     return Result::SUCCESS;
 }
@@ -247,23 +247,26 @@ NRI_INLINE Result SwapChainD3D12::SetLatencySleepMode(const LatencySleepMode& la
 #endif
 }
 
-NRI_INLINE Result SwapChainD3D12::SetLatencyMarker(LatencyMarker latencyMarker) {
+NRI_INLINE Result SwapChainD3D12::SetLatencyMarker(uint64_t presentId, LatencyMarker latencyMarker) {
 #if NRI_ENABLE_NVAPI
     NV_LATENCY_MARKER_PARAMS params = {NV_LATENCY_MARKER_PARAMS_VER};
-    params.frameID = m_PresentId;
+    params.frameID = presentId;
     params.markerType = (NV_LATENCY_MARKER_TYPE)latencyMarker;
 
     NvAPI_Status status = NvAPI_D3D_SetLatencyMarker(m_Device.GetNativeObject(), &params);
 
     return status == NVAPI_OK ? Result::SUCCESS : Result::FAILURE;
 #else
+    MaybeUnused(presentId);
     MaybeUnused(latencyMarker);
 
     return Result::UNSUPPORTED;
 #endif
 }
 
-NRI_INLINE Result SwapChainD3D12::LatencySleep() {
+NRI_INLINE Result SwapChainD3D12::LatencySleep(uint64_t presentId) {
+    MaybeUnused(presentId);
+
 #if NRI_ENABLE_NVAPI
     NvAPI_Status status = NvAPI_D3D_Sleep(m_Device.GetNativeObject());
 

--- a/Source/NONE/ImplNONE.cpp
+++ b/Source/NONE/ImplNONE.cpp
@@ -850,11 +850,11 @@ static Result NRI_CALL SetLatencySleepMode(SwapChain&, const LatencySleepMode&) 
     return Result::SUCCESS;
 }
 
-static Result NRI_CALL SetLatencyMarker(SwapChain&, LatencyMarker) {
+static Result NRI_CALL SetLatencyMarker(SwapChain&, uint64_t, LatencyMarker) {
     return Result::SUCCESS;
 }
 
-static Result NRI_CALL LatencySleep(SwapChain&) {
+static Result NRI_CALL LatencySleep(SwapChain&, uint64_t) {
     return Result::SUCCESS;
 }
 
@@ -1156,11 +1156,11 @@ static Result NRI_CALL AcquireNextTexture(SwapChain&, Fence&, uint32_t& textureI
     return Result::SUCCESS;
 }
 
-static Result NRI_CALL WaitForPresent(SwapChain&) {
+static Result NRI_CALL WaitForPresent(SwapChain&, uint64_t) {
     return Result::SUCCESS;
 }
 
-static Result NRI_CALL QueuePresent(SwapChain&, Fence&) {
+static Result NRI_CALL QueuePresent(SwapChain&, Fence&, uint64_t) {
     return Result::SUCCESS;
 }
 

--- a/Source/Shared/SharedExternal.h
+++ b/Source/Shared/SharedExternal.h
@@ -329,7 +329,6 @@ namespace nri {
 // Internal consts
 constexpr uint32_t NODE_MASK = 0x1;               // mGPU is not planned
 constexpr uint32_t ROOT_SIGNATURE_DWORD_NUM = 64; // https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signature-limits
-constexpr uint64_t PRESENT_INDEX_BIT_NUM = 56ull;
 
 // Scratch
 template <typename T>
@@ -559,13 +558,6 @@ inline bool CompareUid(const Uid_t& a, const Uid_t& b) {
 // Strings
 void ConvertCharToWchar(const char* in, wchar_t* out, size_t outLen);
 void ConvertWcharToChar(const wchar_t* in, char* out, size_t outLen);
-
-// Swap chain ID
-uint64_t GetSwapChainId();
-
-inline uint64_t GetPresentIndex(uint64_t presentId) {
-    return presentId & ((1ull << PRESENT_INDEX_BIT_NUM) - 1ull);
-}
 
 // Windows/D3D specific
 #if (NRI_ENABLE_D3D11_SUPPORT || NRI_ENABLE_D3D12_SUPPORT)

--- a/Source/Shared/SharedExternal.hpp
+++ b/Source/Shared/SharedExternal.hpp
@@ -935,8 +935,3 @@ void nri::ConvertWcharToChar(const wchar_t* in, char* out, size_t outLength) {
 
     *out = 0;
 }
-
-uint64_t nri::GetSwapChainId() {
-    static uint64_t id = 0;
-    return id++ << PRESENT_INDEX_BIT_NUM;
-}

--- a/Source/VK/ImplVK.cpp
+++ b/Source/VK/ImplVK.cpp
@@ -850,12 +850,12 @@ static Result NRI_CALL SetLatencySleepMode(SwapChain& swapChain, const LatencySl
     return ((SwapChainVK&)swapChain).SetLatencySleepMode(latencySleepMode);
 }
 
-static Result NRI_CALL SetLatencyMarker(SwapChain& swapChain, LatencyMarker latencyMarker) {
-    return ((SwapChainVK&)swapChain).SetLatencyMarker(latencyMarker);
+static Result NRI_CALL SetLatencyMarker(SwapChain& swapChain, uint64_t presentId, LatencyMarker latencyMarker) {
+    return ((SwapChainVK&)swapChain).SetLatencyMarker(presentId, latencyMarker);
 }
 
-static Result NRI_CALL LatencySleep(SwapChain& swapChain) {
-    return ((SwapChainVK&)swapChain).LatencySleep();
+static Result NRI_CALL LatencySleep(SwapChain& swapChain, uint64_t presentId) {
+    return ((SwapChainVK&)swapChain).LatencySleep(presentId);
 }
 
 static Result NRI_CALL GetLatencyReport(const SwapChain& swapChain, LatencyReport& latencyReport) {
@@ -1214,12 +1214,12 @@ static Result NRI_CALL AcquireNextTexture(SwapChain& swapChain, Fence& acquireSe
     return ((SwapChainVK&)swapChain).AcquireNextTexture((FenceVK&)acquireSemaphore, textureIndex);
 }
 
-static Result NRI_CALL WaitForPresent(SwapChain& swapChain) {
-    return ((SwapChainVK&)swapChain).WaitForPresent();
+static Result NRI_CALL WaitForPresent(SwapChain& swapChain, uint64_t presentId) {
+    return ((SwapChainVK&)swapChain).WaitForPresent(presentId);
 }
 
-static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence& releaseSemaphore) {
-    return ((SwapChainVK&)swapChain).Present((FenceVK&)releaseSemaphore);
+static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence& releaseSemaphore, uint64_t presentId) {
+    return ((SwapChainVK&)swapChain).Present((FenceVK&)releaseSemaphore, presentId);
 }
 
 Result DeviceVK::FillFunctionTable(SwapChainInterface& table) const {

--- a/Source/VK/QueueVK.hpp
+++ b/Source/VK/QueueVK.hpp
@@ -109,7 +109,7 @@ NRI_INLINE Result QueueVK::Submit(const QueueSubmitDesc& queueSubmitDesc) {
 
     VkLatencySubmissionPresentIdNV presentId = {VK_STRUCTURE_TYPE_LATENCY_SUBMISSION_PRESENT_ID_NV};
     if (queueSubmitDesc.swapChain && m_Device.m_IsSupported.presentId) {
-        presentId.presentID = ((SwapChainVK*)queueSubmitDesc.swapChain)->GetPresentId();
+        presentId.presentID = queueSubmitDesc.presentId;
         submitInfo.pNext = &presentId;
     }
 

--- a/Source/VK/SwapChainVK.h
+++ b/Source/VK/SwapChainVK.h
@@ -16,10 +16,6 @@ struct SwapChainVK final : public DisplayDescHelper, DebugNameBase {
         return m_Device;
     }
 
-    inline uint64_t GetPresentId() const {
-        return m_PresentId;
-    }
-
     Result Create(const SwapChainDesc& swapChainDesc);
 
     //================================================================================================================
@@ -38,12 +34,12 @@ struct SwapChainVK final : public DisplayDescHelper, DebugNameBase {
 
     Texture* const* GetTextures(uint32_t& textureNum) const;
     Result AcquireNextTexture(FenceVK& acquireSemaphore, uint32_t& textureIndex);
-    Result WaitForPresent();
-    Result Present(FenceVK& releaseSemaphore);
+    Result WaitForPresent(uint64_t presentId);
+    Result Present(FenceVK& releaseSemaphore, uint64_t presentId);
 
     Result SetLatencySleepMode(const LatencySleepMode& latencySleepMode);
-    Result SetLatencyMarker(LatencyMarker latencyMarker);
-    Result LatencySleep();
+    Result SetLatencyMarker(uint64_t presentId, LatencyMarker latencyMarker);
+    Result LatencySleep(uint64_t presentId);
     Result GetLatencyReport(LatencyReport& latencyReport);
 
 private:
@@ -54,7 +50,6 @@ private:
     VkSurfaceKHR m_Surface = VK_NULL_HANDLE;
     QueueVK* m_Queue = nullptr;
     void* m_Hwnd = nullptr;
-    uint64_t m_PresentId = 0;
     uint32_t m_TextureIndex = 0;
     SwapChainBits m_Flags = SwapChainBits::NONE;
 };

--- a/Source/VK/SwapChainVK.hpp
+++ b/Source/VK/SwapChainVK.hpp
@@ -415,8 +415,6 @@ Result SwapChainVK::Create(const SwapChainDesc& swapChainDesc) {
 
     // Finalize
     m_Hwnd = swapChainDesc.window.windows.hwnd;
-    m_PresentId = GetSwapChainId();
-
     m_Flags = swapChainDesc.flags;
     if (!allowLowLatency)
         m_Flags &= ~SwapChainBits::ALLOW_LOW_LATENCY;
@@ -456,18 +454,18 @@ NRI_INLINE Result SwapChainVK::AcquireNextTexture(FenceVK& acquireSemaphore, uin
     return Result::SUCCESS;
 }
 
-NRI_INLINE Result SwapChainVK::WaitForPresent() {
-    if (!(m_Flags & SwapChainBits::WAITABLE) || GetPresentIndex(m_PresentId) == 0)
+NRI_INLINE Result SwapChainVK::WaitForPresent(uint64_t presentId) {
+    if (!(m_Flags & SwapChainBits::WAITABLE) || presentId == 0)
         return Result::UNSUPPORTED;
 
     const auto& vk = m_Device.GetDispatchTable();
-    VkResult vkResult = vk.WaitForPresentKHR(m_Device, m_Handle, m_PresentId - 1, MsToUs(NRI_TIMEOUT_PRESENT));
+    VkResult vkResult = vk.WaitForPresentKHR(m_Device, m_Handle, presentId, MsToUs(NRI_TIMEOUT_PRESENT));
     NRI_RETURN_ON_BAD_VKRESULT(&m_Device, vkResult, "WaitForPresentKHR");
 
     return Result::SUCCESS;
 }
 
-NRI_INLINE Result SwapChainVK::Present(FenceVK& releaseSemaphore) {
+NRI_INLINE Result SwapChainVK::Present(FenceVK& releaseSemaphore, uint64_t presentIdValue) {
     ExclusiveScope lock(m_Queue->GetLock());
 
     // Present (wait)
@@ -482,21 +480,19 @@ NRI_INLINE Result SwapChainVK::Present(FenceVK& releaseSemaphore) {
 
     VkPresentIdKHR presentId = {VK_STRUCTURE_TYPE_PRESENT_ID_KHR};
     presentId.swapchainCount = 1;
-    presentId.pPresentIds = &m_PresentId;
-
-    m_PresentId++;
+    presentId.pPresentIds = &presentIdValue;
 
     if (m_Device.m_IsSupported.presentId)
         presentInfo.pNext = &presentId;
 
-    if (m_Flags & SwapChainBits::ALLOW_LOW_LATENCY)
-        SetLatencyMarker((LatencyMarker)VK_LATENCY_MARKER_PRESENT_START_NV);
+    if ((m_Flags & SwapChainBits::ALLOW_LOW_LATENCY) && presentIdValue != 0)
+        SetLatencyMarker(presentIdValue, (LatencyMarker)VK_LATENCY_MARKER_PRESENT_START_NV);
 
     const auto& vk = m_Device.GetDispatchTable();
     VkResult vkResult = vk.QueuePresentKHR(*m_Queue, &presentInfo);
 
-    if (m_Flags & SwapChainBits::ALLOW_LOW_LATENCY)
-        SetLatencyMarker((LatencyMarker)VK_LATENCY_MARKER_PRESENT_END_NV);
+    if ((m_Flags & SwapChainBits::ALLOW_LOW_LATENCY) && presentIdValue != 0)
+        SetLatencyMarker(presentIdValue, (LatencyMarker)VK_LATENCY_MARKER_PRESENT_END_NV);
 
     NRI_RETURN_ON_BAD_VKRESULT(&m_Device, vkResult, "QueuePresentKHR");
 
@@ -516,9 +512,9 @@ NRI_INLINE Result SwapChainVK::SetLatencySleepMode(const LatencySleepMode& laten
     return Result::SUCCESS;
 }
 
-NRI_INLINE Result SwapChainVK::SetLatencyMarker(LatencyMarker latencyMarker) {
+NRI_INLINE Result SwapChainVK::SetLatencyMarker(uint64_t presentId, LatencyMarker latencyMarker) {
     VkSetLatencyMarkerInfoNV markerInfo = {VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV};
-    markerInfo.presentID = m_PresentId;
+    markerInfo.presentID = presentId;
     markerInfo.marker = (VkLatencyMarkerNV)latencyMarker;
 
     const auto& vk = m_Device.GetDispatchTable();
@@ -527,16 +523,16 @@ NRI_INLINE Result SwapChainVK::SetLatencyMarker(LatencyMarker latencyMarker) {
     return Result::SUCCESS;
 }
 
-NRI_INLINE Result SwapChainVK::LatencySleep() {
+NRI_INLINE Result SwapChainVK::LatencySleep(uint64_t presentId) {
     VkLatencySleepInfoNV sleepInfo = {VK_STRUCTURE_TYPE_LATENCY_SLEEP_INFO_NV};
     sleepInfo.signalSemaphore = *m_LatencyFence;
-    sleepInfo.value = m_PresentId;
+    sleepInfo.value = presentId;
 
     const auto& vk = m_Device.GetDispatchTable();
     VkResult vkResult = vk.LatencySleepNV(m_Device, m_Handle, &sleepInfo);
     NRI_RETURN_ON_BAD_VKRESULT(&m_Device, vkResult, "LatencySleepNV");
 
-    m_LatencyFence->Wait(m_PresentId); // VK_SUCCESS is guaranteed by "NRI_RETURN_ON_BAD_VKRESULT"
+    m_LatencyFence->Wait(presentId); // VK_SUCCESS is guaranteed by "NRI_RETURN_ON_BAD_VKRESULT"
 
     return Result::SUCCESS;
 }

--- a/Source/Validation/ImplVal.cpp
+++ b/Source/Validation/ImplVal.cpp
@@ -907,12 +907,12 @@ static Result NRI_CALL SetLatencySleepMode(SwapChain& swapChain, const LatencySl
     return ((SwapChainVal&)swapChain).SetLatencySleepMode(latencySleepMode);
 }
 
-static Result NRI_CALL SetLatencyMarker(SwapChain& swapChain, LatencyMarker latencyMarker) {
-    return ((SwapChainVal&)swapChain).SetLatencyMarker(latencyMarker);
+static Result NRI_CALL SetLatencyMarker(SwapChain& swapChain, uint64_t presentId, LatencyMarker latencyMarker) {
+    return ((SwapChainVal&)swapChain).SetLatencyMarker(presentId, latencyMarker);
 }
 
-static Result NRI_CALL LatencySleep(SwapChain& swapChain) {
-    return ((SwapChainVal&)swapChain).LatencySleep();
+static Result NRI_CALL LatencySleep(SwapChain& swapChain, uint64_t presentId) {
+    return ((SwapChainVal&)swapChain).LatencySleep(presentId);
 }
 
 static Result NRI_CALL GetLatencyReport(const SwapChain& swapChain, LatencyReport& latencyReport) {
@@ -1367,12 +1367,12 @@ static Result NRI_CALL AcquireNextTexture(SwapChain& swapChain, Fence& acquireSe
     return ((SwapChainVal&)swapChain).AcquireNextTexture(acquireSemaphore, textureIndex);
 }
 
-static Result NRI_CALL WaitForPresent(SwapChain& swapChain) {
-    return ((SwapChainVal&)swapChain).WaitForPresent();
+static Result NRI_CALL WaitForPresent(SwapChain& swapChain, uint64_t presentId) {
+    return ((SwapChainVal&)swapChain).WaitForPresent(presentId);
 }
 
-static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence& releaseSemaphore) {
-    return ((SwapChainVal&)swapChain).Present(releaseSemaphore);
+static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence& releaseSemaphore, uint64_t presentId) {
+    return ((SwapChainVal&)swapChain).Present(releaseSemaphore, presentId);
 }
 
 Result DeviceVal::FillFunctionTable(SwapChainInterface& table) const {

--- a/Source/Validation/QueueVal.hpp
+++ b/Source/Validation/QueueVal.hpp
@@ -20,6 +20,8 @@ NRI_INLINE void QueueVal::GetCalibratedTimestamps(uint64_t& timestampGPU, uint64
 }
 
 NRI_INLINE Result QueueVal::Submit(const QueueSubmitDesc& queueSubmitDesc) {
+    NRI_RETURN_ON_FAILURE(&m_Device, !queueSubmitDesc.swapChain || queueSubmitDesc.presentId != 0, Result::INVALID_ARGUMENT, "'presentId' is 0");
+
     auto queueSubmitDescImpl = queueSubmitDesc;
 
     Scratch<FenceSubmitDesc> waitFences = NRI_ALLOCATE_SCRATCH(m_Device, FenceSubmitDesc, queueSubmitDesc.waitFenceNum);

--- a/Source/Validation/SwapChainVal.h
+++ b/Source/Validation/SwapChainVal.h
@@ -23,13 +23,13 @@ struct SwapChainVal final : public ObjectVal {
 
     Texture* const* GetTextures(uint32_t& textureNum);
     Result AcquireNextTexture(Fence& acquireSemaphore, uint32_t& textureIndex);
-    Result WaitForPresent();
-    Result Present(Fence& releaseSemaphore);
+    Result WaitForPresent(uint64_t presentId);
+    Result Present(Fence& releaseSemaphore, uint64_t presentId);
     Result GetDisplayDesc(DisplayDesc& displayDesc) const;
 
     Result SetLatencySleepMode(const LatencySleepMode& latencySleepMode);
-    Result SetLatencyMarker(LatencyMarker latencyMarker);
-    Result LatencySleep();
+    Result SetLatencyMarker(uint64_t presentId, LatencyMarker latencyMarker);
+    Result LatencySleep(uint64_t presentId);
     Result GetLatencyReport(LatencyReport& latencyReport);
 
 private:

--- a/Source/Validation/SwapChainVal.hpp
+++ b/Source/Validation/SwapChainVal.hpp
@@ -24,19 +24,20 @@ NRI_INLINE Result SwapChainVal::AcquireNextTexture(Fence& acquireSemaphore, uint
     return GetSwapChainInterfaceImpl().AcquireNextTexture(*GetImpl(), *textureAcquiredSemaphoreImpl, textureIndex);
 }
 
-NRI_INLINE Result SwapChainVal::WaitForPresent() {
+NRI_INLINE Result SwapChainVal::WaitForPresent(uint64_t presentId) {
+    NRI_RETURN_ON_FAILURE(&m_Device, presentId != 0, Result::INVALID_ARGUMENT, "'presentId' is 0");
     NRI_RETURN_ON_FAILURE(&m_Device, m_SwapChainDesc.flags & SwapChainBits::WAITABLE, Result::FAILURE, "Swap chain has not been created with 'WAITABLE' flag");
 
     const DeviceDesc& deviceDesc = m_Device.GetDesc();
     NRI_RETURN_ON_FAILURE(&m_Device, deviceDesc.features.waitableSwapChain, Result::FAILURE, "'features.waitableSwapChain' is false");
 
-    return GetSwapChainInterfaceImpl().WaitForPresent(*GetImpl());
+    return GetSwapChainInterfaceImpl().WaitForPresent(*GetImpl(), presentId);
 }
 
-NRI_INLINE Result SwapChainVal::Present(Fence& releaseSemaphore) {
+NRI_INLINE Result SwapChainVal::Present(Fence& releaseSemaphore, uint64_t presentId) {
     Fence* renderingFinishedSemaphoreImpl = NRI_GET_IMPL(Fence, &releaseSemaphore);
 
-    return GetSwapChainInterfaceImpl().QueuePresent(*GetImpl(), *renderingFinishedSemaphoreImpl);
+    return GetSwapChainInterfaceImpl().QueuePresent(*GetImpl(), *renderingFinishedSemaphoreImpl, presentId);
 }
 
 NRI_INLINE Result SwapChainVal::GetDisplayDesc(DisplayDesc& displayDesc) const {
@@ -52,22 +53,24 @@ NRI_INLINE Result SwapChainVal::SetLatencySleepMode(const LatencySleepMode& late
     return GetLowLatencyInterfaceImpl().SetLatencySleepMode(*GetImpl(), latencySleepMode);
 }
 
-NRI_INLINE Result SwapChainVal::SetLatencyMarker(LatencyMarker latencyMarker) {
+NRI_INLINE Result SwapChainVal::SetLatencyMarker(uint64_t presentId, LatencyMarker latencyMarker) {
+    NRI_RETURN_ON_FAILURE(&m_Device, presentId != 0, Result::INVALID_ARGUMENT, "'presentId' is 0");
     NRI_RETURN_ON_FAILURE(&m_Device, m_SwapChainDesc.flags & SwapChainBits::ALLOW_LOW_LATENCY, Result::FAILURE, "Swap chain has not been created with 'ALLOW_LOW_LATENCY' flag");
 
     const DeviceDesc& deviceDesc = m_Device.GetDesc();
     NRI_RETURN_ON_FAILURE(&m_Device, deviceDesc.features.lowLatency, Result::FAILURE, "'features.lowLatency' is false");
 
-    return GetLowLatencyInterfaceImpl().SetLatencyMarker(*GetImpl(), latencyMarker);
+    return GetLowLatencyInterfaceImpl().SetLatencyMarker(*GetImpl(), presentId, latencyMarker);
 }
 
-NRI_INLINE Result SwapChainVal::LatencySleep() {
+NRI_INLINE Result SwapChainVal::LatencySleep(uint64_t presentId) {
+    NRI_RETURN_ON_FAILURE(&m_Device, presentId != 0, Result::INVALID_ARGUMENT, "'presentId' is 0");
     NRI_RETURN_ON_FAILURE(&m_Device, m_SwapChainDesc.flags & SwapChainBits::ALLOW_LOW_LATENCY, Result::FAILURE, "Swap chain has not been created with 'ALLOW_LOW_LATENCY' flag");
 
     const DeviceDesc& deviceDesc = m_Device.GetDesc();
     NRI_RETURN_ON_FAILURE(&m_Device, deviceDesc.features.lowLatency, Result::FAILURE, "'features.lowLatency' is false");
 
-    return GetLowLatencyInterfaceImpl().LatencySleep(*GetImpl());
+    return GetLowLatencyInterfaceImpl().LatencySleep(*GetImpl(), presentId);
 }
 
 NRI_INLINE Result SwapChainVal::GetLatencyReport(LatencyReport& latencyReport) {

--- a/Source/WGPU/ImplWGPU.cpp
+++ b/Source/WGPU/ImplWGPU.cpp
@@ -947,11 +947,11 @@ static Result NRI_CALL AcquireNextTexture(SwapChain& swapChain, Fence&, uint32_t
     return ((SwapChainWGPU&)swapChain).AcquireNextTexture(textureIndex);
 }
 
-static Result NRI_CALL WaitForPresent(SwapChain& swapChain) {
+static Result NRI_CALL WaitForPresent(SwapChain& swapChain, uint64_t) {
     return ((SwapChainWGPU&)swapChain).WaitForPresent();
 }
 
-static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence&) {
+static Result NRI_CALL QueuePresent(SwapChain& swapChain, Fence&, uint64_t) {
     return ((SwapChainWGPU&)swapChain).Present();
 }
 


### PR DESCRIPTION
This is required for applications (like mine) that place rendering on a dedicated thread