### PR TITLE
Add configurable FFX debug logging

### DIFF
--- a/Source/NRIConfig.h
+++ b/Source/NRIConfig.h
@@ -20,6 +20,16 @@
 #endif
 */
 
+// FFX stuff
+
+/*
+#define NRI_FFX_DEBUG_LOG(messageType, message) \
+    do { \
+        MaybeUnused(messageType); \
+        wprintf(L"FFX: %ls\n", message); \
+    } while (false)
+*/
+
 // D3D12MA stuff
 
 /*

--- a/Source/Shared/SharedExternal.h
+++ b/Source/Shared/SharedExternal.h
@@ -85,6 +85,15 @@ typedef uint32_t DXGI_FORMAT;
 #    define NRI_INLINE inline
 #endif
 
+// FFX default settings (if not provided in "NRIConfig.h")
+#ifndef NRI_FFX_DEBUG_LOG
+#    define NRI_FFX_DEBUG_LOG(messageType, message) \
+        do { \
+            MaybeUnused(messageType); \
+            wprintf(L"FFX: %ls\n", message); \
+        } while (false)
+#endif
+
 // D3D12MA default settings (if not provided in "NRIConfig.h")
 #ifndef D3D12MA_DEBUG_LOG
 #    define D3D12MA_DEBUG_LOG(format, ...) \

--- a/Source/Shared/UpscalerInterface.hpp
+++ b/Source/Shared/UpscalerInterface.hpp
@@ -283,11 +283,8 @@ static void FfxDealloc(void* pUserData, void* pMem) {
 
 #    ifndef NDEBUG
 
-static void FfxDebugMessage(uint32_t, const wchar_t* message) {
-    char s[1024];
-    ConvertWcharToChar(message, s, sizeof(s));
-
-    printf("FFX: %s\n", s);
+static void FfxDebugMessage(uint32_t messageType, const wchar_t* message) {
+    NRI_FFX_DEBUG_LOG(messageType, message);
 }
 
 #    endif


### PR DESCRIPTION
Route FFX validation messages through an NRI user-config hook, matching the existing third-party allocator logging overrides while preserving the current console fallback.