### PR TITLE
Fix: sync ImTextureData with upstream ImGui layout

### DIFF
--- a/Include/Extensions/NRIImgui.h
+++ b/Include/Extensions/NRIImgui.h
@@ -8,7 +8,8 @@
 
 /*
 Requirements:
-- ImGui 1.92+ with "ImGuiBackendFlags_RendererHasTextures" flag ("IMGUI_DISABLE_OBSOLETE_FUNCTIONS" is recommended)
+- ImGui 1.92.9+ with "ImGuiBackendFlags_RendererHasTextures" flag ("IMGUI_DISABLE_OBSOLETE_FUNCTIONS" is recommended),
+  ("QueueUserData" field was added to "ImTextureData" in 1.92.9)
 - unmodified "ImDrawVert" (20 bytes) and "ImDrawIdx" (2 bytes)
 - "ImTextureID_Invalid" = 0
 

--- a/Source/Shared/ImguiInterface.hpp
+++ b/Source/Shared/ImguiInterface.hpp
@@ -289,6 +289,7 @@ struct ImTextureData {
     int UniqueID;
     ImTextureStatus Status;
     void* BackendUserData;
+    void* QueueUserData;
     ImTextureID TexID;
     ImTextureFormat Format;
     int Width;


### PR DESCRIPTION
## Sync ImTextureData with upstream ImGui layout

This syncs the `ImTextureData` struct in `Source/Shared/ImguiInterface.hpp` with the current ImGui layout (matching ocornut/imgui@b335bf4).

### Why this matters

The upstream ImGui `ImTextureData` struct gained a new `QueueUserData` field:

```cpp
struct ImTextureData {
    int UniqueID;
    ImTextureStatus Status;
    void* BackendUserData;
    void* QueueUserData;   // <-- added in upstream
    ImTextureID TexID;
    ...
};
```

Because NRI's copy of this struct was missing that field, the two layouts drifted apart. The field ordering and offsets no longer match, which corrupts the memory layout when ImGui and NRI share this struct. This breaks using ImGui textures with NRI.

This change adds the missing `QueueUserData` field back, restoring the correct layout.