### PR TITLE
Fix: case sensitivity in #include

### DIFF
--- a/Resources/NRI.rc
+++ b/Resources/NRI.rc
@@ -2,7 +2,7 @@
 // If NDR.rc does not comile, try re-saving it with UTF-8 encoding.
 // After editing VS2019 saves it as UTF-8 with BOM.
 #pragma code_page(65001)
-#include "version.h"
+#include "Version.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Cross-compiling for windows on linux build agents fails with:
```cpp
/build/_deps/nri-src/Resources/NRI.rc:5:10: fatal error: 'version.h' file not found
    5 | #include "version.h"
      |          ^~~~~~~~~~~
1 error generated.
```

This happens because the include references `Version.h` (capital V), which resolves fine on windows's case-insensitive filesystem but not on linux.