### PR TITLE
Add StoreOp::NONE for read-only attachments

### DIFF
--- a/Include/NRIDescs.h
+++ b/Include/NRIDescs.h
@@ -1626,7 +1626,9 @@ NriEnum(LoadOp, uint8_t,
 // https://docs.vulkan.org/refpages/latest/refpages/source/VkAttachmentStoreOp.html
 NriEnum(StoreOp, uint8_t,
     STORE,
-    DISCARD
+    DISCARD,
+    NONE        // ProjectKiwi patch: VK_ATTACHMENT_STORE_OP_NONE, no write access at all, for attachments the pass
+                // never writes (read-only depth). Legacy VK render passes and the other backends treat it as STORE.
 );
 
 // https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_resolve_mode

--- a/Include/NRIDescs.h
+++ b/Include/NRIDescs.h
@@ -1627,8 +1627,7 @@ NriEnum(LoadOp, uint8_t,
 NriEnum(StoreOp, uint8_t,
     STORE,
     DISCARD,
-    NONE        // ProjectKiwi patch: VK_ATTACHMENT_STORE_OP_NONE, no write access at all, for attachments the pass
-                // never writes (read-only depth). Legacy VK render passes and the other backends treat it as STORE.
+    NONE
 );
 
 // https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_resolve_mode

--- a/Source/VK/CommandBufferVK.hpp
+++ b/Source/VK/CommandBufferVK.hpp
@@ -283,7 +283,9 @@ static inline RenderPassAttachmentDesc GetRenderPassAttachmentDesc(const Attachm
     out.format = GetVkFormat(descriptorVK.GetFormat());
     out.sampleNum = (VkSampleCountFlagBits)texViewDesc.texture->GetDesc().sampleNum;
     out.loadOp = GetLoadOp(attachmentDesc.loadOp);
-    out.storeOp = GetStoreOp(attachmentDesc.storeOp);
+    // ProjectKiwi patch: legacy render passes run on devices without VK 1.3, where STORE_OP_NONE may be unavailable
+    // as well, so degrade it to a plain store
+    out.storeOp = attachmentDesc.storeOp == StoreOp::NONE ? VK_ATTACHMENT_STORE_OP_STORE : GetStoreOp(attachmentDesc.storeOp);
     out.stencilLoadOp = out.loadOp;
     out.stencilStoreOp = out.storeOp;
     out.layout = isInputAttachment ? VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ : texViewDesc.expectedLayout;

--- a/Source/VK/CommandBufferVK.hpp
+++ b/Source/VK/CommandBufferVK.hpp
@@ -283,8 +283,7 @@ static inline RenderPassAttachmentDesc GetRenderPassAttachmentDesc(const Attachm
     out.format = GetVkFormat(descriptorVK.GetFormat());
     out.sampleNum = (VkSampleCountFlagBits)texViewDesc.texture->GetDesc().sampleNum;
     out.loadOp = GetLoadOp(attachmentDesc.loadOp);
-    // ProjectKiwi patch: legacy render passes run on devices without VK 1.3, where STORE_OP_NONE may be unavailable
-    // as well, so degrade it to a plain store
+    // STORE_OP_NONE may be unavailable on legacy render path, conservatively revert to STORE
     out.storeOp = attachmentDesc.storeOp == StoreOp::NONE ? VK_ATTACHMENT_STORE_OP_STORE : GetStoreOp(attachmentDesc.storeOp);
     out.stencilLoadOp = out.loadOp;
     out.stencilStoreOp = out.storeOp;

--- a/Source/VK/ConversionVK.h
+++ b/Source/VK/ConversionVK.h
@@ -35,6 +35,7 @@ constexpr VkAttachmentLoadOp GetLoadOp(LoadOp loadOp) {
 constexpr std::array<VkAttachmentStoreOp, (size_t)StoreOp::MAX_NUM> g_StoreOps = {
     VK_ATTACHMENT_STORE_OP_STORE,     // STORE
     VK_ATTACHMENT_STORE_OP_DONT_CARE, // DISCARD
+    VK_ATTACHMENT_STORE_OP_NONE,      // NONE (ProjectKiwi patch; core since VK 1.3)
 };
 NRI_VALIDATE_ARRAY(g_StoreOps);
 

--- a/Source/VK/ConversionVK.h
+++ b/Source/VK/ConversionVK.h
@@ -35,7 +35,7 @@ constexpr VkAttachmentLoadOp GetLoadOp(LoadOp loadOp) {
 constexpr std::array<VkAttachmentStoreOp, (size_t)StoreOp::MAX_NUM> g_StoreOps = {
     VK_ATTACHMENT_STORE_OP_STORE,     // STORE
     VK_ATTACHMENT_STORE_OP_DONT_CARE, // DISCARD
-    VK_ATTACHMENT_STORE_OP_NONE,      // NONE (ProjectKiwi patch; core since VK 1.3)
+    VK_ATTACHMENT_STORE_OP_NONE,      // NONE
 };
 NRI_VALIDATE_ARRAY(g_StoreOps);
 


### PR DESCRIPTION
VK_VERSION_1_3 gives us VK_ATTACHMENT_STORE_OP_NONE, this maps it from StoreOp::NONE. This allows us to avoid store-time write access for read-only attachments like depth buffers. StoreOp seems to not be in use in DX api.

AI DISCLAIMER: Fable 5.1 found this issue while working on our vulkan renderer and it seems correct to me, I had GPT-6 Astra review it for good measure.